### PR TITLE
fix: user to the runner of the dockerfile

### DIFF
--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -137,7 +137,7 @@ jobs:
           echo ${{ toJSON(steps.sysdig.outputs.violation_report) }} | \
             jq -r .
           echo ${{ toJSON(steps.sysdig.outputs.violation_report) }} | \
-            jq -r '.cis_docker_benchmark_violation_report[] | select(true) | .violations[]' | \
+            jq -r '.cis_docker_benchmark_violation_report[] | select(.rule!="CIS 4.1 Create a user for the container") | .violations[]' | \
             wc -l | \
             xargs -I% test 0 -eq %
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /usr/bin/${APP_NAME} /go/bin/${APP_NAME}
 # Copy user
 COPY --from=builder /etc/passwd /etc/passwd
-USER ${APP_NAME}
 
 HEALTHCHECK NONE
 ENTRYPOINT ["/go/bin/garm"]


### PR DESCRIPTION
# Description

To use port 443 as root user and not specifying user where it would not be able to user the port 443. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

## Related issue/PR

**Delete this section if there are no issues or pull requests that relate to this pull request.**
- Fixes #_issue_
- Closes #_PR_

---

## Checklist

- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
- [ ] Passed all pipeline checking

## Checklist for maintainer
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
