### PR TITLE
Handles both requests v1beta1 and v1 of api/authorization

### DIFF
--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -121,6 +121,7 @@ func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAcces
 			Allowed: rV1Beta1.Status.Allowed,
 			Denied:  rV1Beta1.Status.Denied,
 			Reason:  rV1Beta1.Status.Reason,
+			EvaluationError:  rV1Beta1.Status.EvaluationError,
 		},
 	}
 }

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -91,13 +91,18 @@ func (a *authorizer) clientX509(ctx context.Context) (*client, error) {
 }
 
 func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAccessReview {
+	v1Extra := make(map[string]authz.ExtraValue)
+	for key, value := range rV1Beta1.Spec.Extra {
+		v1Extra[key] = authz.ExtraValue(value)
+	}
+
 	return authz.SubjectAccessReview{
 		TypeMeta:   rV1Beta1.TypeMeta,
 		ObjectMeta: rV1Beta1.ObjectMeta,
 		Spec: authz.SubjectAccessReviewSpec{
-			User: rV1Beta1.Spec.User,
-			UID:  rV1Beta1.Spec.UID,
-			// Extra: r2.Spec.Extra, // TODO: How to copy the extra from v1beta to v1?
+			User:                  rV1Beta1.Spec.User,
+			UID:                   rV1Beta1.Spec.UID,
+			Extra:                 v1Extra,
 			Groups:                rV1Beta1.Spec.Groups,
 			NonResourceAttributes: (*authz.NonResourceAttributes)(rV1Beta1.Spec.DeepCopy().NonResourceAttributes),
 			ResourceAttributes: &authz.ResourceAttributes{

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/kpango/glg"
 	authz "k8s.io/api/authorization/v1"
 	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,19 +142,14 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 		return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 	}
 	if r.APIVersion == authzSupportedBetaVersion {
-		glg.Info("[deprecated] received '%s' will be deleted in the near future", authzSupportedBetaVersion) // TODO: Delete me
 		var rV1Beta1 authzv1beta1.SubjectAccessReview
 		if err := json.Unmarshal(b, &rV1Beta1); err != nil {
 			return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 		}
-		glg.Info("Data", convertIntoV1(rV1Beta1)) // TODO: Delete me
 		r = convertIntoV1(rV1Beta1)
-	} else {
-		glg.Info("Did not run!!!") // TODO: Delete me
 	}
 	if r.APIVersion != authzSupportedVersion {
-		// TODO: fixme: Remove it
-		return nil, fmt.Errorf("fixme: unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
+		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
 	}
 	if r.Kind != authzSupportedKind {
 		return nil, fmt.Errorf("unsupported authorization kind, want '%s', got '%s'", authzSupportedKind, r.Kind)

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -112,12 +112,13 @@ func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAcces
 				Verb: rV1Beta1.Spec.NonResourceAttributes.Verb,
 			},
 			ResourceAttributes: &authz.ResourceAttributes{
-				Namespace: rV1Beta1.Spec.ResourceAttributes.Namespace,
-				Verb:      rV1Beta1.Spec.ResourceAttributes.Verb,
-				Group:     rV1Beta1.Spec.ResourceAttributes.Group,
-				Version:   rV1Beta1.Spec.ResourceAttributes.Version,
-				Resource:  rV1Beta1.Spec.ResourceAttributes.Resource,
-				Name:      rV1Beta1.Spec.ResourceAttributes.Name,
+				Namespace:   rV1Beta1.Spec.ResourceAttributes.Namespace,
+				Verb:        rV1Beta1.Spec.ResourceAttributes.Verb,
+				Group:       rV1Beta1.Spec.ResourceAttributes.Group,
+				Version:     rV1Beta1.Spec.ResourceAttributes.Version,
+				Resource:    rV1Beta1.Spec.ResourceAttributes.Resource,
+				Subresource: rV1Beta1.Spec.ResourceAttributes.Subresource,
+				Name:        rV1Beta1.Spec.ResourceAttributes.Name,
 			},
 		},
 		Status: authz.SubjectAccessReviewStatus{
@@ -145,6 +146,7 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 	if err := json.Unmarshal(b, &r); err != nil {
 		return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 	}
+	// TODO: This is a temporary fix to support both v1 and v1beta1 versions of SubjectAccessReview & will be removed in future.
 	if r.APIVersion == authzSupportedBetaVersion {
 		var rV1Beta1 authzv1beta1.SubjectAccessReview
 		if err := json.Unmarshal(b, &rV1Beta1); err != nil {

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -153,9 +153,9 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 	} else {
 		glg.Info("Did not run!!!") // TODO: Delete me
 	}
-	// if r.APIVersion != authzSupportedVersion {
-	// 	return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
-	// }
+	if r.APIVersion != authzSupportedVersion {
+		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
+	}
 	if r.Kind != authzSupportedKind {
 		return nil, fmt.Errorf("unsupported authorization kind, want '%s', got '%s'", authzSupportedKind, r.Kind)
 	}

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -103,11 +103,14 @@ func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAcces
 		},
 		ObjectMeta: *rV1Beta1.ObjectMeta.DeepCopy(),
 		Spec: authz.SubjectAccessReviewSpec{
-			User:                  rV1Beta1.Spec.User,
-			UID:                   rV1Beta1.Spec.UID,
-			Extra:                 v1Extra,
-			Groups:                rV1Beta1.Spec.Groups,
-			NonResourceAttributes: (*authz.NonResourceAttributes)(rV1Beta1.Spec.DeepCopy().NonResourceAttributes),
+			User:   rV1Beta1.Spec.User,
+			UID:    rV1Beta1.Spec.UID,
+			Extra:  v1Extra,
+			Groups: rV1Beta1.Spec.Groups,
+			NonResourceAttributes: &authz.NonResourceAttributes{
+				Path: rV1Beta1.Spec.NonResourceAttributes.Path,
+				Verb: rV1Beta1.Spec.NonResourceAttributes.Verb,
+			},
 			ResourceAttributes: &authz.ResourceAttributes{
 				Namespace: rV1Beta1.Spec.ResourceAttributes.Namespace,
 				Verb:      rV1Beta1.Spec.ResourceAttributes.Verb,
@@ -118,10 +121,10 @@ func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAcces
 			},
 		},
 		Status: authz.SubjectAccessReviewStatus{
-			Allowed: rV1Beta1.Status.Allowed,
-			Denied:  rV1Beta1.Status.Denied,
-			Reason:  rV1Beta1.Status.Reason,
-			EvaluationError:  rV1Beta1.Status.EvaluationError,
+			Allowed:         rV1Beta1.Status.Allowed,
+			Denied:          rV1Beta1.Status.Denied,
+			Reason:          rV1Beta1.Status.Reason,
+			EvaluationError: rV1Beta1.Status.EvaluationError,
 		},
 	}
 }

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -141,6 +141,8 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 		}
 		glg.Info("Data", convertIntoV1(rV1Beta1)) // TODO: Delete me
 		r = convertIntoV1(rV1Beta1)
+	} else {
+		glg.Info("Did not run!!!") // TODO: Delete me
 	}
 	if r.APIVersion != authzSupportedVersion {
 		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kpango/glg"
 	authz "k8s.io/api/authorization/v1"
 	authzv1beta1 "k8s.io/api/authorization/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -97,7 +98,10 @@ func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAcces
 	}
 
 	return authz.SubjectAccessReview{
-		TypeMeta:   rV1Beta1.TypeMeta,
+		TypeMeta: metav1.TypeMeta{
+			Kind:       rV1Beta1.Kind,
+			APIVersion: authzSupportedVersion,
+		},
 		ObjectMeta: rV1Beta1.ObjectMeta,
 		Spec: authz.SubjectAccessReviewSpec{
 			User:                  rV1Beta1.Spec.User,

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -101,7 +101,7 @@ func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAcces
 			Kind:       rV1Beta1.Kind,
 			APIVersion: authzSupportedVersion,
 		},
-		ObjectMeta: rV1Beta1.ObjectMeta,
+		ObjectMeta: *rV1Beta1.ObjectMeta.DeepCopy(),
 		Spec: authz.SubjectAccessReviewSpec{
 			User:                  rV1Beta1.Spec.User,
 			UID:                   rV1Beta1.Spec.UID,

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -154,7 +154,8 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 		glg.Info("Did not run!!!") // TODO: Delete me
 	}
 	if r.APIVersion != authzSupportedVersion {
-		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
+		// TODO: fixme: Remove it
+		return nil, fmt.Errorf("fixme: unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
 	}
 	if r.Kind != authzSupportedKind {
 		return nil, fmt.Errorf("unsupported authorization kind, want '%s', got '%s'", authzSupportedKind, r.Kind)

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -89,29 +89,29 @@ func (a *authorizer) clientX509(ctx context.Context) (*client, error) {
 	return newClient(a.ZMSEndpoint, a.ZTSEndpoint, a.Timeout, xpX509), nil
 }
 
-func convertIntoV1(sarV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAccessReview {
+func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAccessReview {
 	return authz.SubjectAccessReview{
-		TypeMeta:   sarV1Beta1.TypeMeta,
-		ObjectMeta: sarV1Beta1.ObjectMeta,
+		TypeMeta:   rV1Beta1.TypeMeta,
+		ObjectMeta: rV1Beta1.ObjectMeta,
 		Spec: authz.SubjectAccessReviewSpec{
-			User: sarV1Beta1.Spec.User,
-			UID:  sarV1Beta1.Spec.UID,
+			User: rV1Beta1.Spec.User,
+			UID:  rV1Beta1.Spec.UID,
 			// Extra: r2.Spec.Extra, // TODO: How to copy the extra from v1beta to v1?
-			Groups:                sarV1Beta1.Spec.Groups,
-			NonResourceAttributes: (*authz.NonResourceAttributes)(sarV1Beta1.Spec.DeepCopy().NonResourceAttributes),
+			Groups:                rV1Beta1.Spec.Groups,
+			NonResourceAttributes: (*authz.NonResourceAttributes)(rV1Beta1.Spec.DeepCopy().NonResourceAttributes),
 			ResourceAttributes: &authz.ResourceAttributes{
-				Namespace: sarV1Beta1.Spec.ResourceAttributes.Namespace,
-				Verb:      sarV1Beta1.Spec.ResourceAttributes.Verb,
-				Group:     sarV1Beta1.Spec.ResourceAttributes.Group,
-				Version:   sarV1Beta1.Spec.ResourceAttributes.Version,
-				Resource:  sarV1Beta1.Spec.ResourceAttributes.Resource,
-				Name:      sarV1Beta1.Spec.ResourceAttributes.Name,
+				Namespace: rV1Beta1.Spec.ResourceAttributes.Namespace,
+				Verb:      rV1Beta1.Spec.ResourceAttributes.Verb,
+				Group:     rV1Beta1.Spec.ResourceAttributes.Group,
+				Version:   rV1Beta1.Spec.ResourceAttributes.Version,
+				Resource:  rV1Beta1.Spec.ResourceAttributes.Resource,
+				Name:      rV1Beta1.Spec.ResourceAttributes.Name,
 			},
 		},
 		Status: authz.SubjectAccessReviewStatus{
-			Allowed: sarV1Beta1.Status.Allowed,
-			Denied:  sarV1Beta1.Status.Denied,
-			Reason:  sarV1Beta1.Status.Reason,
+			Allowed: rV1Beta1.Status.Allowed,
+			Denied:  rV1Beta1.Status.Denied,
+			Reason:  rV1Beta1.Status.Reason,
 		},
 	}
 }
@@ -128,27 +128,27 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 	if isLogEnabled(ctx, LogTraceServer) {
 		getLogger(ctx).Printf("request body: %s\n", b)
 	}
-	var sar authz.SubjectAccessReview
-	if err := json.Unmarshal(b, &sar); err != nil {
+	var r authz.SubjectAccessReview
+	if err := json.Unmarshal(b, &r); err != nil {
 		return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 	}
-	if sar.APIVersion == authzSupportedBetaVersion {
-		var sarV1Beta1 authzv1beta1.SubjectAccessReview
-		if err := json.Unmarshal(b, &sarV1Beta1); err != nil {
+	if r.APIVersion == authzSupportedBetaVersion {
+		var rV1Beta1 authzv1beta1.SubjectAccessReview
+		if err := json.Unmarshal(b, &rV1Beta1); err != nil {
 			return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 		}
-		sar = convertIntoV1(sarV1Beta1)
+		r = convertIntoV1(rV1Beta1)
 	}
-	if sar.APIVersion != authzSupportedVersion {
-		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, sar.APIVersion)
+	if r.APIVersion != authzSupportedVersion {
+		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
 	}
-	if sar.Kind != authzSupportedKind {
-		return nil, fmt.Errorf("unsupported authorization kind, want '%s', got '%s'", authzSupportedKind, sar.Kind)
+	if r.Kind != authzSupportedKind {
+		return nil, fmt.Errorf("unsupported authorization kind, want '%s', got '%s'", authzSupportedKind, r.Kind)
 	}
-	if sar.Spec.ResourceAttributes == nil && sar.Spec.NonResourceAttributes == nil {
+	if r.Spec.ResourceAttributes == nil && r.Spec.NonResourceAttributes == nil {
 		return nil, fmt.Errorf("bad authorization spec, must have one of resource or non-resource attributes")
 	}
-	return &sar, nil
+	return &r, nil
 }
 
 // grantStatus adds extra information to a review status.

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/kpango/glg"
 	authz "k8s.io/api/authorization/v1"
 	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
@@ -133,10 +134,12 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 		return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 	}
 	if r.APIVersion == authzSupportedBetaVersion {
+		glg.Info("[deprecated] received '%s' will be deleted in the near future", authzSupportedBetaVersion) // TODO: Delete me
 		var rV1Beta1 authzv1beta1.SubjectAccessReview
 		if err := json.Unmarshal(b, &rV1Beta1); err != nil {
 			return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 		}
+		glg.Info("Data", convertIntoV1(rV1Beta1)) // TODO: Delete me
 		r = convertIntoV1(rV1Beta1)
 	}
 	if r.APIVersion != authzSupportedVersion {

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -153,9 +153,9 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 	} else {
 		glg.Info("Did not run!!!") // TODO: Delete me
 	}
-	if r.APIVersion != authzSupportedVersion {
-		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
-	}
+	// if r.APIVersion != authzSupportedVersion {
+	// 	return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
+	// }
 	if r.Kind != authzSupportedKind {
 		return nil, fmt.Errorf("unsupported authorization kind, want '%s', got '%s'", authzSupportedKind, r.Kind)
 	}

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -90,6 +90,7 @@ func (a *authorizer) clientX509(ctx context.Context) (*client, error) {
 	return newClient(a.ZMSEndpoint, a.ZTSEndpoint, a.Timeout, xpX509), nil
 }
 
+// TODO: convertIntoV1() is a temporary fix to support both v1 and v1beta1 versions of SubjectAccessReview & will be removed in future.
 func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAccessReview {
 	v1Extra := make(map[string]authz.ExtraValue)
 	for key, value := range rV1Beta1.Spec.Extra {

--- a/third_party/webhook/authz_test.go
+++ b/third_party/webhook/authz_test.go
@@ -471,7 +471,8 @@ func TestAuthzBadInputs(t *testing.T) {
 	}{
 		{400, nil, "empty body for authorization request"},
 		{400, badKind(), "unsupported authorization kind, want 'SubjectAccessReview', got 'foo'"},
-		{400, badVersion(), "unsupported authorization version, want 'authorization.k8s.io/v1', got 'foo'"},
+		// TODO: Fix me later
+		{400, badVersion(), "fixme: unsupported authorization version, want 'authorization.k8s.io/v1', got 'foo'"},
 		{400, emptyStruct(), "bad authorization spec, must have one of resource or non-resource attributes"},
 		{400, append(serialize(base), 'X'), "invalid JSON request"},
 	}

--- a/third_party/webhook/authz_test.go
+++ b/third_party/webhook/authz_test.go
@@ -471,8 +471,7 @@ func TestAuthzBadInputs(t *testing.T) {
 	}{
 		{400, nil, "empty body for authorization request"},
 		{400, badKind(), "unsupported authorization kind, want 'SubjectAccessReview', got 'foo'"},
-		// TODO: Fix me later
-		{400, badVersion(), "fixme: unsupported authorization version, want 'authorization.k8s.io/v1', got 'foo'"},
+		{400, badVersion(), "unsupported authorization version, want 'authorization.k8s.io/v1', got 'foo'"},
 		{400, emptyStruct(), "bad authorization spec, must have one of resource or non-resource attributes"},
 		{400, append(serialize(base), 'X'), "invalid JSON request"},
 	}


### PR DESCRIPTION
# Description

Now supports both `v1beta1` and `v1` of `authorization` request, by converting given `v1beta1` into `v1`

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Passed all pipeline checking

## Checklist for maintainer
- [x] Use `Squash and merge`
- [x] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [x] Delete the branch after merge
