### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -104,14 +104,11 @@ func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAcces
 		},
 		ObjectMeta: *rV1Beta1.ObjectMeta.DeepCopy(),
 		Spec: authz.SubjectAccessReviewSpec{
-			User:   rV1Beta1.Spec.User,
-			UID:    rV1Beta1.Spec.UID,
-			Extra:  v1Extra,
-			Groups: rV1Beta1.Spec.Groups,
-			NonResourceAttributes: &authz.NonResourceAttributes{
-				Path: rV1Beta1.Spec.NonResourceAttributes.Path,
-				Verb: rV1Beta1.Spec.NonResourceAttributes.Verb,
-			},
+			User:                  rV1Beta1.Spec.User,
+			UID:                   rV1Beta1.Spec.UID,
+			Extra:                 v1Extra,
+			Groups:                rV1Beta1.Spec.Groups,
+			NonResourceAttributes: (*authz.NonResourceAttributes)(rV1Beta1.Spec.DeepCopy().NonResourceAttributes),
 			ResourceAttributes: &authz.ResourceAttributes{
 				Namespace:   rV1Beta1.Spec.ResourceAttributes.Namespace,
 				Verb:        rV1Beta1.Spec.ResourceAttributes.Verb,


### PR DESCRIPTION
# Description

We encountered a bug while attempting to recover from a panic in the Athenz webhook: a runtime error occurred due to an invalid memory address or nil pointer dereference.

Also added temporary unit test just in case.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

## Related issue/PR

- Fixes #22

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Passed all pipeline checking

## Checklist for maintainer
- [x] Use `Squash and merge`
- [x] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [x] Delete the branch after merge
