### PR TITLE
Fix v1beta1 -> v1 Conversion Logic with More Test

### DIFF
--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -213,7 +213,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -213,8 +213,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name == 'pull_request' }}
-          load: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ env.DOCKER_BUILDX_PLATFORM }}

--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -214,7 +214,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name == 'pull_request' }}
-          load: ${{ github.event_name == 'pull_request' }}
+          load: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ env.DOCKER_BUILDX_PLATFORM }}

--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -215,7 +215,7 @@ jobs:
           context: .
           push: ${{ github.event_name == 'pull_request' }}
           load: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: nightly
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ env.DOCKER_BUILDX_PLATFORM }}
           build-args: |

--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -215,7 +215,7 @@ jobs:
           context: .
           push: ${{ github.event_name == 'pull_request' }}
           load: ${{ github.event_name != 'pull_request' }}
-          tags: nightly
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ env.DOCKER_BUILDX_PLATFORM }}
           build-args: |

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -11,7 +11,6 @@ import (
 
 	authz "k8s.io/api/authorization/v1"
 	authzv1beta1 "k8s.io/api/authorization/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -90,47 +89,6 @@ func (a *authorizer) clientX509(ctx context.Context) (*client, error) {
 	return newClient(a.ZMSEndpoint, a.ZTSEndpoint, a.Timeout, xpX509), nil
 }
 
-// TODO: convertIntoV1() is a temporary fix to support both v1 and v1beta1 versions of SubjectAccessReview & will be removed in future.
-func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAccessReview {
-	v1Extra := make(map[string]authz.ExtraValue)
-	for key, value := range rV1Beta1.Spec.Extra {
-		v1Extra[key] = authz.ExtraValue(value)
-	}
-
-	return authz.SubjectAccessReview{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       rV1Beta1.Kind,
-			APIVersion: authzSupportedVersion,
-		},
-		ObjectMeta: *rV1Beta1.ObjectMeta.DeepCopy(),
-		Spec: authz.SubjectAccessReviewSpec{
-			User:   rV1Beta1.Spec.User,
-			UID:    rV1Beta1.Spec.UID,
-			Extra:  v1Extra,
-			Groups: rV1Beta1.Spec.Groups,
-			NonResourceAttributes: &authz.NonResourceAttributes{
-				Path: rV1Beta1.Spec.NonResourceAttributes.Path,
-				Verb: rV1Beta1.Spec.NonResourceAttributes.Verb,
-			},
-			ResourceAttributes: &authz.ResourceAttributes{
-				Namespace:   rV1Beta1.Spec.ResourceAttributes.Namespace,
-				Verb:        rV1Beta1.Spec.ResourceAttributes.Verb,
-				Group:       rV1Beta1.Spec.ResourceAttributes.Group,
-				Version:     rV1Beta1.Spec.ResourceAttributes.Version,
-				Resource:    rV1Beta1.Spec.ResourceAttributes.Resource,
-				Subresource: rV1Beta1.Spec.ResourceAttributes.Subresource,
-				Name:        rV1Beta1.Spec.ResourceAttributes.Name,
-			},
-		},
-		Status: authz.SubjectAccessReviewStatus{
-			Allowed:         rV1Beta1.Status.Allowed,
-			Denied:          rV1Beta1.Status.Denied,
-			Reason:          rV1Beta1.Status.Reason,
-			EvaluationError: rV1Beta1.Status.EvaluationError,
-		},
-	}
-}
-
 // getSubjectAccessReview extracts the subject access review object from the request and returns it.
 func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Request) (*authz.SubjectAccessReview, error) {
 	b, err := ioutil.ReadAll(req.Body)
@@ -153,7 +111,8 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 		if err := json.Unmarshal(b, &rV1Beta1); err != nil {
 			return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 		}
-		r = convertIntoV1(rV1Beta1)
+		r.APIVersion = authzSupportedVersion
+		r.Spec.Groups = rV1Beta1.Spec.Groups
 	}
 	if r.APIVersion != authzSupportedVersion {
 		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -113,7 +113,7 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 			return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 		}
 		r = ConvertIntoV1(rV1Beta1)
-		glg.Warn("Your cluster is using deprecated authorization.k8s.io/v1beta instead of authorization.k8s.io/v1", "convertedFrom", rV1Beta1, "convertedTo", r)
+		glg.Warn("Your cluster is using deprecated authorization.k8s.io/v1beta1 instead of authorization.k8s.io/v1", "convertedFrom", rV1Beta1, "convertedTo", r)
 	}
 	if r.APIVersion != authzSupportedVersion {
 		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -112,9 +112,8 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 		if err := json.Unmarshal(b, &rV1Beta1); err != nil {
 			return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 		}
-		glg.Info("🔴 rV1Beta1", rV1Beta1)
 		r = ConvertIntoV1(rV1Beta1)
-		glg.Info("🔵 converted rV1Beta1", r)
+		glg.Warn("Your cluster is using deprecated authorization.k8s.io/v1beta instead of authorization.k8s.io/v1", "convertedFrom", rV1Beta1, "convertedTo", r)
 	}
 	if r.APIVersion != authzSupportedVersion {
 		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/kpango/glg"
 	authz "k8s.io/api/authorization/v1"
 	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
@@ -111,8 +112,9 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 		if err := json.Unmarshal(b, &rV1Beta1); err != nil {
 			return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 		}
-		r.APIVersion = authzSupportedVersion
-		r.Spec.Groups = rV1Beta1.Spec.Groups
+		glg.Info("🔴 rV1Beta1", rV1Beta1)
+		r = ConvertIntoV1(rV1Beta1)
+		glg.Info("🔵 converted rV1Beta1", rV1Beta1)
 	}
 	if r.APIVersion != authzSupportedVersion {
 		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -114,7 +114,7 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 		}
 		glg.Info("🔴 rV1Beta1", rV1Beta1)
 		r = ConvertIntoV1(rV1Beta1)
-		glg.Info("🔵 converted rV1Beta1", rV1Beta1)
+		glg.Info("🔵 converted rV1Beta1", r)
 	}
 	if r.APIVersion != authzSupportedVersion {
 		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -91,40 +91,42 @@ func (a *authorizer) clientX509(ctx context.Context) (*client, error) {
 }
 
 // getSubjectAccessReview extracts the subject access review object from the request and returns it.
-func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Request) (*authz.SubjectAccessReview, error) {
+func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Request) (bool, *authz.SubjectAccessReview, error) {
+	isV1Beta := false // TODO: Remove me! Temporary fix to support both v1 and v1beta1 versions of SubjectAccessReview.
 	b, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		return nil, fmt.Errorf("body read error for authorization request, %v", err)
+		return isV1Beta, nil, fmt.Errorf("body read error for authorization request, %v", err)
 	}
 	if len(b) == 0 {
-		return nil, fmt.Errorf("empty body for authorization request")
+		return isV1Beta, nil, fmt.Errorf("empty body for authorization request")
 	}
 	if isLogEnabled(ctx, LogTraceServer) {
 		getLogger(ctx).Printf("request body: %s\n", b)
 	}
 	var r authz.SubjectAccessReview
 	if err := json.Unmarshal(b, &r); err != nil {
-		return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
+		return isV1Beta, nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 	}
-	// TODO: This is a temporary fix to support both v1 and v1beta1 versions of SubjectAccessReview & will be removed in future.
+	// TODO: Remove me! This is a temporary fix to support both v1 and v1beta1 versions of SubjectAccessReview & will be removed in future.
 	if r.APIVersion == authzSupportedBetaVersion {
+		isV1Beta = true
 		var rV1Beta1 authzv1beta1.SubjectAccessReview
 		if err := json.Unmarshal(b, &rV1Beta1); err != nil {
-			return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
+			return isV1Beta, nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 		}
 		r = ConvertIntoV1(rV1Beta1)
 		glg.Warn("Your cluster is using deprecated authorization.k8s.io/v1beta1 instead of authorization.k8s.io/v1", "convertedFrom", rV1Beta1, "convertedTo", r)
 	}
 	if r.APIVersion != authzSupportedVersion {
-		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
+		return isV1Beta, nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)
 	}
 	if r.Kind != authzSupportedKind {
-		return nil, fmt.Errorf("unsupported authorization kind, want '%s', got '%s'", authzSupportedKind, r.Kind)
+		return isV1Beta, nil, fmt.Errorf("unsupported authorization kind, want '%s', got '%s'", authzSupportedKind, r.Kind)
 	}
 	if r.Spec.ResourceAttributes == nil && r.Spec.NonResourceAttributes == nil {
-		return nil, fmt.Errorf("bad authorization spec, must have one of resource or non-resource attributes")
+		return isV1Beta, nil, fmt.Errorf("bad authorization spec, must have one of resource or non-resource attributes")
 	}
-	return &r, nil
+	return isV1Beta, &r, nil
 }
 
 // grantStatus adds extra information to a review status.
@@ -321,7 +323,7 @@ func (a *authorizer) logOutcome(logger Logger, sr *authz.SubjectAccessReviewSpec
 
 func (a *authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	sr, err := a.getSubjectAccessReview(ctx, r)
+	isV1Beta, sr, err := a.getSubjectAccessReview(ctx, r)
 	if err != nil {
 		getLogger(ctx).Printf("authz request error from %s: %v\n", r.RemoteAddr, err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -331,10 +333,16 @@ func (a *authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	gs := a.authorize(ctx, sr.Spec)
 	a.logOutcome(getLogger(ctx), &sr.Spec, gs)
 
+	// TODO: Remove me! Temporary Tweaks to support both v1 and v1beta1
+	apiVersion := sr.APIVersion
+	if isV1Beta {
+		apiVersion = authzSupportedBetaVersion
+	}
+
 	resp := struct {
 		APIVersion string                          `json:"apiVersion"`
 		Kind       string                          `json:"kind"`
 		Status     authz.SubjectAccessReviewStatus `json:"status"`
-	}{sr.APIVersion, sr.Kind, gs.status}
+	}{apiVersion, sr.Kind, gs.status}
 	writeJSON(ctx, w, &resp)
 }

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -115,7 +115,7 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 			return isV1Beta, nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 		}
 		r = ConvertIntoV1(rV1Beta1)
-		glg.Warn("Your cluster is using deprecated authorization.k8s.io/v1beta1 instead of authorization.k8s.io/v1", "convertedFrom", rV1Beta1, "convertedTo", r)
+		glg.Warn("Your cluster is using deprecated authorization.k8s.io/v1beta1 instead of authorization.k8s.io/v1", "convertedFrom:", rV1Beta1, "convertedTo:", r)
 	}
 	if r.APIVersion != authzSupportedVersion {
 		return isV1Beta, nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/kpango/glg"
 	authz "k8s.io/api/authorization/v1"
 	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
@@ -115,7 +114,7 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 			return isV1Beta, nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
 		}
 		r = ConvertIntoV1(rV1Beta1)
-		glg.Warn("Your cluster is using deprecated authorization.k8s.io/v1beta1 instead of authorization.k8s.io/v1", "convertedFrom:", rV1Beta1, "convertedTo:", r)
+		// glg.Warn("Your cluster is using deprecated authorization.k8s.io/v1beta1 instead of authorization.k8s.io/v1", "convertedFrom:", rV1Beta1, "convertedTo:", r)
 	}
 	if r.APIVersion != authzSupportedVersion {
 		return isV1Beta, nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	authz "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -88,6 +90,47 @@ func (a *authorizer) clientX509(ctx context.Context) (*client, error) {
 	return newClient(a.ZMSEndpoint, a.ZTSEndpoint, a.Timeout, xpX509), nil
 }
 
+// TODO: convertIntoV1() is a temporary fix to support both v1 and v1beta1 versions of SubjectAccessReview & will be removed in future.
+func convertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAccessReview {
+	v1Extra := make(map[string]authz.ExtraValue)
+	for key, value := range rV1Beta1.Spec.Extra {
+		v1Extra[key] = authz.ExtraValue(value)
+	}
+
+	return authz.SubjectAccessReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       rV1Beta1.Kind,
+			APIVersion: authzSupportedVersion,
+		},
+		ObjectMeta: *rV1Beta1.ObjectMeta.DeepCopy(),
+		Spec: authz.SubjectAccessReviewSpec{
+			User:   rV1Beta1.Spec.User,
+			UID:    rV1Beta1.Spec.UID,
+			Extra:  v1Extra,
+			Groups: rV1Beta1.Spec.Groups,
+			NonResourceAttributes: &authz.NonResourceAttributes{
+				Path: rV1Beta1.Spec.NonResourceAttributes.Path,
+				Verb: rV1Beta1.Spec.NonResourceAttributes.Verb,
+			},
+			ResourceAttributes: &authz.ResourceAttributes{
+				Namespace:   rV1Beta1.Spec.ResourceAttributes.Namespace,
+				Verb:        rV1Beta1.Spec.ResourceAttributes.Verb,
+				Group:       rV1Beta1.Spec.ResourceAttributes.Group,
+				Version:     rV1Beta1.Spec.ResourceAttributes.Version,
+				Resource:    rV1Beta1.Spec.ResourceAttributes.Resource,
+				Subresource: rV1Beta1.Spec.ResourceAttributes.Subresource,
+				Name:        rV1Beta1.Spec.ResourceAttributes.Name,
+			},
+		},
+		Status: authz.SubjectAccessReviewStatus{
+			Allowed:         rV1Beta1.Status.Allowed,
+			Denied:          rV1Beta1.Status.Denied,
+			Reason:          rV1Beta1.Status.Reason,
+			EvaluationError: rV1Beta1.Status.EvaluationError,
+		},
+	}
+}
+
 // getSubjectAccessReview extracts the subject access review object from the request and returns it.
 func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Request) (*authz.SubjectAccessReview, error) {
 	b, err := ioutil.ReadAll(req.Body)
@@ -106,8 +149,11 @@ func (a *authorizer) getSubjectAccessReview(ctx context.Context, req *http.Reque
 	}
 	// TODO: This is a temporary fix to support both v1 and v1beta1 versions of SubjectAccessReview & will be removed in future.
 	if r.APIVersion == authzSupportedBetaVersion {
-		// This is feasible as the only difference between v1 and v1beta1 is the APIVersion.
-		r.APIVersion = authzSupportedVersion
+		var rV1Beta1 authzv1beta1.SubjectAccessReview
+		if err := json.Unmarshal(b, &rV1Beta1); err != nil {
+			return nil, fmt.Errorf("invalid JSON request '%s', %v", b, err)
+		}
+		r = convertIntoV1(rV1Beta1)
 	}
 	if r.APIVersion != authzSupportedVersion {
 		return nil, fmt.Errorf("unsupported authorization version, want '%s', got '%s'", authzSupportedVersion, r.APIVersion)

--- a/third_party/webhook/authz_test.go
+++ b/third_party/webhook/authz_test.go
@@ -14,11 +14,11 @@ import (
 	"time"
 
 	authz "k8s.io/api/authorization/v1"
-	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var helpText = "help me!"
+var expectedApiVersion = authzSupportedVersion
 
 func TestAuthzError(t *testing.T) {
 	e := NewAuthzError(errors.New("foobar"), "this is bad")
@@ -191,6 +191,9 @@ func TestAuthzHappyPath(t *testing.T) {
 		t.Error("invalid ZMS URL path", urlPath)
 	}
 	tr := checkGrant(t, body.Bytes(), true)
+	if tr.APIVersion != expectedApiVersion {
+		t.Errorf("wrong API version. Want '%s', got '%s'", expectedApiVersion, tr.APIVersion)
+	}
 	if tr.Kind != input.Kind {
 		t.Error("invalid Kind", tr.Kind)
 	}
@@ -223,6 +226,9 @@ func TestAuthzHappyPathX509(t *testing.T) {
 		t.Error("invalid ZMS URL path", urlPath)
 	}
 	tr := checkGrant(t, body.Bytes(), true)
+	if tr.APIVersion != expectedApiVersion {
+		t.Errorf("wrong API version. Want '%s', got '%s'", expectedApiVersion, tr.APIVersion)
+	}
 	if tr.Kind != input.Kind {
 		t.Error("invalid Kind", tr.Kind)
 	}
@@ -260,6 +266,9 @@ func TestAuthzZMSReject(t *testing.T) {
 				t.Fatal("invalid status code", w.Result().StatusCode)
 			}
 			tr := checkGrant(t, body.Bytes(), false)
+			if tr.APIVersion != expectedApiVersion {
+				t.Errorf("wrong API version. Want '%s', got '%s'", expectedApiVersion, tr.APIVersion)
+			}
 			if tr.Status.EvaluationError == "" {
 				t.Error("eval error not set")
 			}
@@ -308,6 +317,9 @@ func TestAuthzMapperError(t *testing.T) {
 		t.Fatal("invalid status code", w.Result().StatusCode)
 	}
 	tr := checkGrant(t, body.Bytes(), false)
+	if tr.APIVersion != expectedApiVersion {
+		t.Errorf("wrong API version. Want '%s', got '%s'", expectedApiVersion, tr.APIVersion)
+	}
 	msg := "mapping error: foobar"
 	if tr.Status.EvaluationError != msg {
 		t.Errorf("want '%s', got '%s'", msg, tr.Status.EvaluationError)
@@ -316,64 +328,6 @@ func TestAuthzMapperError(t *testing.T) {
 		t.Error("authz internals leak")
 	}
 	s.containsLog(msg)
-}
-
-// TODO: This is a temporary test to ensure that the old API version is still supported & will be eventually removed.
-
-func stdAuthzBeta1Input(insertingGroup []string) authzv1beta1.SubjectAccessReview {
-	return authzv1beta1.SubjectAccessReview{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       authzSupportedKind,
-			APIVersion: authzSupportedBetaVersion,
-		},
-		Spec: authzv1beta1.SubjectAccessReviewSpec{
-			User: "bob",
-			ResourceAttributes: &authzv1beta1.ResourceAttributes{
-				Namespace: "foo-bar",
-				Verb:      "get",
-				Resource:  "baz",
-			},
-			Groups: insertingGroup,
-		},
-	}
-}
-
-// TODO: This is a temporary test to ensure that the old API version is still supported & will be eventually removed.
-func TestAuthzBetaV1ApiConversion(t *testing.T) {
-	s := newAuthzScaffold(t)
-	defer s.Close()
-	s.config.Mapper = mrfn(func(ctx context.Context, spec authz.SubjectAccessReviewSpec) (principal string, checks []AthenzAccessCheck, err error) {
-		return "",
-			nil,
-			errors.New("foobar")
-	})
-	insertingGroups := [][]string{
-		{"v1beta1-testing", "v1beta1-group"}, // multiple elements
-		{},                                   // empty group
-		nil,                                  // not defined
-	}
-
-	for _, insertingGroup := range insertingGroups {
-		input := stdAuthzBeta1Input(insertingGroup)
-		ar := runAuthzTest(s, serialize(input), nil)
-		fmt.Printf("input: %+v\n", ar.body)
-		w := ar.w
-		body := ar.body
-
-		if w.Result().StatusCode != 200 {
-			t.Fatal("invalid status code", w.Result().StatusCode)
-		}
-		tr := checkGrant(t, body.Bytes(), false)
-
-		msg := "mapping error: foobar"
-		if tr.Status.EvaluationError != msg {
-			t.Errorf("want '%s', got '%s'", msg, tr.Status.EvaluationError)
-		}
-		if tr.Status.Reason != helpText {
-			t.Error("authz internals leak")
-		}
-		s.containsLog(msg)
-	}
 }
 
 func TestAuthzTokenErrors(t *testing.T) {
@@ -391,6 +345,9 @@ func TestAuthzTokenErrors(t *testing.T) {
 		t.Fatal("invalid status code", w.Result().StatusCode)
 	}
 	tr := checkGrant(t, body.Bytes(), false)
+	if tr.APIVersion != expectedApiVersion {
+		t.Errorf("wrong API version. Want '%s', got '%s'", expectedApiVersion, tr.APIVersion)
+	}
 	msg := "no token for you"
 	if tr.Status.EvaluationError != msg {
 		t.Errorf("want '%s', got '%s'", msg, tr.Status.EvaluationError)
@@ -416,6 +373,9 @@ func TestAuthzBadToken(t *testing.T) {
 		t.Fatal("invalid status code", w.Result().StatusCode)
 	}
 	tr := checkGrant(t, body.Bytes(), false)
+	if tr.APIVersion != expectedApiVersion {
+		t.Errorf("wrong API version. Want '%s', got '%s'", expectedApiVersion, tr.APIVersion)
+	}
 	reason := "internal setup error." + helpText
 	if tr.Status.Reason != reason {
 		t.Errorf("reason mismatch: want '%s', got'%s'", reason, tr.Status.Reason)
@@ -437,6 +397,9 @@ func TestAuthzAthenz400(t *testing.T) {
 		t.Fatal("invalid status code", w.Result().StatusCode)
 	}
 	tr := checkGrant(t, body.Bytes(), false)
+	if tr.APIVersion != expectedApiVersion {
+		t.Errorf("wrong API version. Want '%s', got '%s'", expectedApiVersion, tr.APIVersion)
+	}
 	reason := "Invalid ResourceName error."
 	if tr.Status.Reason != reason {
 		t.Errorf("reason mismatch: want '%s', got'%s'", reason, tr.Status.Reason)
@@ -459,6 +422,9 @@ func TestAuthzAthenz404(t *testing.T) {
 		t.Fatal("invalid status code", w.Result().StatusCode)
 	}
 	tr := checkGrant(t, body.Bytes(), false)
+	if tr.APIVersion != expectedApiVersion {
+		t.Errorf("wrong API version. Want '%s', got '%s'", expectedApiVersion, tr.APIVersion)
+	}
 	reason := "" // Continue to the the next check
 	if tr.Status.Reason != reason {
 		t.Errorf("reason mismatch: want '%s', got'%s'", reason, tr.Status.Reason)
@@ -486,6 +452,9 @@ func TestAuthzAthenz500(t *testing.T) {
 		t.Fatal("invalid status code", w.Result().StatusCode)
 	}
 	tr := checkGrant(t, body.Bytes(), false)
+	if tr.APIVersion != expectedApiVersion {
+		t.Errorf("wrong API version. Want '%s', got '%s'", expectedApiVersion, tr.APIVersion)
+	}
 	if tr.Status.Reason != helpText {
 		t.Errorf("reason mismatch: want '%s', got'%s'", helpText, tr.Status.Reason)
 	}

--- a/third_party/webhook/authz_test.go
+++ b/third_party/webhook/authz_test.go
@@ -126,6 +126,7 @@ func stdAuthzInput() authz.SubjectAccessReview {
 				Verb:      "get",
 				Resource:  "baz",
 			},
+			Groups: []string{"v1-testing", "v1-group"},
 		},
 	}
 }
@@ -318,7 +319,8 @@ func TestAuthzMapperError(t *testing.T) {
 }
 
 // TODO: This is a temporary test to ensure that the old API version is still supported & will be eventually removed.
-func stdAuthzBeta1Input() authzv1beta1.SubjectAccessReview {
+
+func stdAuthzBeta1Input(insertingGroup []string) authzv1beta1.SubjectAccessReview {
 	return authzv1beta1.SubjectAccessReview{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       authzSupportedKind,
@@ -331,6 +333,7 @@ func stdAuthzBeta1Input() authzv1beta1.SubjectAccessReview {
 				Verb:      "get",
 				Resource:  "baz",
 			},
+			Groups: insertingGroup,
 		},
 	}
 }
@@ -344,23 +347,33 @@ func TestAuthzBetaV1ApiConversion(t *testing.T) {
 			nil,
 			errors.New("foobar")
 	})
-	input := stdAuthzBeta1Input()
-	ar := runAuthzTest(s, serialize(input), nil)
-	w := ar.w
-	body := ar.body
+	insertingGroups := [][]string{
+		{"v1beta1-testing", "v1beta1-group"}, // multiple elements
+		{},                                   // empty group
+		nil,                                  // not defined
+	}
 
-	if w.Result().StatusCode != 200 {
-		t.Fatal("invalid status code", w.Result().StatusCode)
+	for _, insertingGroup := range insertingGroups {
+		input := stdAuthzBeta1Input(insertingGroup)
+		ar := runAuthzTest(s, serialize(input), nil)
+		fmt.Printf("input: %+v\n", ar.body)
+		w := ar.w
+		body := ar.body
+
+		if w.Result().StatusCode != 200 {
+			t.Fatal("invalid status code", w.Result().StatusCode)
+		}
+		tr := checkGrant(t, body.Bytes(), false)
+
+		msg := "mapping error: foobar"
+		if tr.Status.EvaluationError != msg {
+			t.Errorf("want '%s', got '%s'", msg, tr.Status.EvaluationError)
+		}
+		if tr.Status.Reason != helpText {
+			t.Error("authz internals leak")
+		}
+		s.containsLog(msg)
 	}
-	tr := checkGrant(t, body.Bytes(), false)
-	msg := "mapping error: foobar"
-	if tr.Status.EvaluationError != msg {
-		t.Errorf("want '%s', got '%s'", msg, tr.Status.EvaluationError)
-	}
-	if tr.Status.Reason != helpText {
-		t.Error("authz internals leak")
-	}
-	s.containsLog(msg)
 }
 
 func TestAuthzTokenErrors(t *testing.T) {

--- a/third_party/webhook/authz_v1beta1_test.go
+++ b/third_party/webhook/authz_v1beta1_test.go
@@ -80,32 +80,3 @@ func TestAuthzBetaV1ApiConversion(t *testing.T) {
 		tester(t, stdAuthzBeta1Input(insertingGroup))
 	}
 }
-
-func stdAuthzBeta1InputWithoutGroups(insertingGroup []string) authzv1beta1.SubjectAccessReview {
-	return authzv1beta1.SubjectAccessReview{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       authzSupportedKind,
-			APIVersion: authzSupportedBetaVersion,
-		},
-		Spec: authzv1beta1.SubjectAccessReviewSpec{
-			User: "bob",
-			ResourceAttributes: &authzv1beta1.ResourceAttributes{
-				Namespace: "foo-bar",
-				Verb:      "get",
-				Resource:  "baz",
-			},
-		},
-	}
-}
-
-func TestAuthzBetaV1ApiWithoutGroups(t *testing.T) {
-	insertingGroups := [][]string{
-		{"v1beta1-testing", "v1beta1-group"}, // multiple elements
-		{},                                   // empty group
-		nil,                                  // not defined
-	}
-
-	for _, insertingGroup := range insertingGroups {
-		tester(t, stdAuthzBeta1InputWithoutGroups(insertingGroup))
-	}
-}

--- a/third_party/webhook/authz_v1beta1_test.go
+++ b/third_party/webhook/authz_v1beta1_test.go
@@ -1,0 +1,78 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	authz "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TODO: Remove this file authz_v1beta1_test.go! This is a temporary test to ensure that the old API version is still supported & will be eventually removed.
+
+// TODO: This is a temporary test to ensure that the old API version is still supported & will be eventually removed.
+
+func stdAuthzBeta1Input(insertingGroup []string) authzv1beta1.SubjectAccessReview {
+	return authzv1beta1.SubjectAccessReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       authzSupportedKind,
+			APIVersion: authzSupportedBetaVersion,
+		},
+		Spec: authzv1beta1.SubjectAccessReviewSpec{
+			User: "bob",
+			ResourceAttributes: &authzv1beta1.ResourceAttributes{
+				Namespace: "foo-bar",
+				Verb:      "get",
+				Resource:  "baz",
+			},
+			Groups: insertingGroup,
+		},
+	}
+}
+
+// TODO: This is a temporary test to ensure that the old API version is still supported & will be eventually removed.
+func TestAuthzBetaV1ApiConversion(t *testing.T) {
+	s := newAuthzScaffold(t)
+	defer s.Close()
+	s.config.Mapper = mrfn(func(ctx context.Context, spec authz.SubjectAccessReviewSpec) (principal string, checks []AthenzAccessCheck, err error) {
+		return "",
+			nil,
+			errors.New("foobar")
+	})
+	insertingGroups := [][]string{
+		{"v1beta1-testing", "v1beta1-group"}, // multiple elements
+		{},                                   // empty group
+		nil,                                  // not defined
+	}
+
+	for _, insertingGroup := range insertingGroups {
+		input := stdAuthzBeta1Input(insertingGroup)
+		ar := runAuthzTest(s, serialize(input), nil)
+		fmt.Printf("input: %+v\n", ar.body)
+		w := ar.w
+		body := ar.body
+		result := w.Result()
+		fmt.Print(result)
+
+		if result.StatusCode != 200 {
+			t.Fatal("invalid status code", result.StatusCode)
+		}
+		tr := checkGrant(t, body.Bytes(), false)
+
+		if tr.APIVersion != authzSupportedBetaVersion {
+			t.Errorf("wrong API version. Want '%s', got '%s'", authzSupportedBetaVersion, tr.APIVersion)
+		}
+
+		msg := "mapping error: foobar"
+		if tr.Status.EvaluationError != msg {
+			t.Errorf("want '%s', got '%s'", msg, tr.Status.EvaluationError)
+		}
+		if tr.Status.Reason != helpText {
+			t.Error("authz internals leak")
+		}
+		s.containsLog(msg)
+	}
+}

--- a/third_party/webhook/authz_v1beta1_test.go
+++ b/third_party/webhook/authz_v1beta1_test.go
@@ -3,7 +3,6 @@ package webhook
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	authz "k8s.io/api/authorization/v1"
@@ -25,11 +24,9 @@ func tester(t *testing.T, input authzv1beta1.SubjectAccessReview) {
 	})
 
 	ar := runAuthzTest(s, serialize(input), nil)
-	fmt.Printf("input: %+v\n", ar.body)
 	w := ar.w
 	body := ar.body
 	result := w.Result()
-	fmt.Print(result)
 
 	if result.StatusCode != 200 {
 		t.Fatal("invalid status code", result.StatusCode)

--- a/third_party/webhook/converter.go
+++ b/third_party/webhook/converter.go
@@ -1,0 +1,97 @@
+package webhook
+
+// TODO: This whole converter is temporary.
+import (
+	authz "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getExtras(rV1Beta1 *authzv1beta1.SubjectAccessReview) map[string]authz.ExtraValue {
+	v1Extra := make(map[string]authz.ExtraValue)
+	if rV1Beta1 == nil || rV1Beta1.Spec.Extra == nil {
+		return v1Extra
+	}
+
+	for key, value := range rV1Beta1.Spec.Extra {
+		v1Extra[key] = authz.ExtraValue(value)
+	}
+	return v1Extra
+}
+
+func getNonResourceAttributes(rV1Beta1 *authzv1beta1.SubjectAccessReview) (nra *authz.NonResourceAttributes) {
+	if rV1Beta1 == nil || rV1Beta1.Spec.NonResourceAttributes == nil {
+		return nra
+	}
+
+	nra = &authz.NonResourceAttributes{
+		Path: rV1Beta1.Spec.NonResourceAttributes.Path,
+		Verb: rV1Beta1.Spec.NonResourceAttributes.Verb,
+	}
+	return nra
+}
+
+func getResourceAttributes(rV1Beta1 *authzv1beta1.SubjectAccessReview) (ra *authz.ResourceAttributes) {
+	if rV1Beta1 == nil || rV1Beta1.Spec.ResourceAttributes == nil {
+		return ra
+	}
+
+	ra = &authz.ResourceAttributes{
+		Namespace:   rV1Beta1.Spec.ResourceAttributes.Namespace,
+		Verb:        rV1Beta1.Spec.ResourceAttributes.Verb,
+		Group:       rV1Beta1.Spec.ResourceAttributes.Group,
+		Version:     rV1Beta1.Spec.ResourceAttributes.Version,
+		Resource:    rV1Beta1.Spec.ResourceAttributes.Resource,
+		Subresource: rV1Beta1.Spec.ResourceAttributes.Subresource,
+		Name:        rV1Beta1.Spec.ResourceAttributes.Name,
+	}
+	return ra
+}
+
+func getSpec(rV1Beta1 *authzv1beta1.SubjectAccessReview) (spec authz.SubjectAccessReviewSpec) {
+	if rV1Beta1 == nil {
+		return spec
+	}
+	spec = authz.SubjectAccessReviewSpec{
+		User:                  rV1Beta1.Spec.User,
+		UID:                   rV1Beta1.Spec.UID,
+		Extra:                 getExtras(rV1Beta1),
+		Groups:                rV1Beta1.Spec.Groups,
+		NonResourceAttributes: getNonResourceAttributes(rV1Beta1),
+		ResourceAttributes:    getResourceAttributes(rV1Beta1),
+	}
+	return spec
+}
+
+func getStatus(rV1Beta1 *authzv1beta1.SubjectAccessReview) (status authz.SubjectAccessReviewStatus) {
+	if rV1Beta1 == nil {
+		return status
+	}
+	status = authz.SubjectAccessReviewStatus{
+		Allowed:         rV1Beta1.Status.Allowed,
+		Denied:          rV1Beta1.Status.Denied,
+		Reason:          rV1Beta1.Status.Reason,
+		EvaluationError: rV1Beta1.Status.EvaluationError,
+	}
+	return status
+}
+
+func getObjectMeta(rV1Beta1 *authzv1beta1.SubjectAccessReview) (om metav1.ObjectMeta) {
+	if rV1Beta1 == nil {
+		return om
+	}
+	om = *rV1Beta1.ObjectMeta.DeepCopy()
+	return om
+}
+
+func ConvertIntoV1(rV1Beta1 authzv1beta1.SubjectAccessReview) authz.SubjectAccessReview {
+	return authz.SubjectAccessReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       rV1Beta1.Kind,
+			APIVersion: authzSupportedVersion,
+		},
+		ObjectMeta: getObjectMeta(&rV1Beta1),
+		Spec:       getSpec(&rV1Beta1),
+		Status:     getStatus(&rV1Beta1),
+	}
+}


### PR DESCRIPTION
# Description
We've updated Garm to accept both v1beta1 and v1 requests by converting v1beta1 requests into v1. However, the conversion process had a bug related to nil pointer dereference.

## TODOs
- [X] Converting algorithm in a separate file
- [X] Converting algorithm with nil point reference handled.
- [X] v1beta1 related test in a separate file
- [X] v1beta1 request will return v1beta1 response
- [X] Returned API Version test for v1 and v1beta1

## Type of change

- [X] Bug fix
- [ ] New feature
- [X] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

## Related issue/PR

- Fixes #22
- Fixes #25
- Fixes #26

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Passed all pipeline checking

## Checklist for maintainer
- [x] Use `Squash and merge`
- [x] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [x] Delete the branch after merge
