### PR TITLE
Prototype: Garm uses x509 certificate over ntoken

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,9 +69,9 @@ type Config struct {
 
 // TODO: Comment me
 type X509Config struct {
-	Cert         string `yaml:"cert"`
-	Key          string `yaml:"key"`
-	CA           string `yaml:"ca"`
+	Cert string `yaml:"cert"`
+	Key  string `yaml:"key"`
+	CA   string `yaml:"ca"`
 }
 
 // Logger represents logging configuration for Garm.

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,9 @@ const (
 // Config represents an application configuration content (config.yaml).
 // In K8s environment, this configuration is stored in K8s ConfigMap.
 type Config struct {
+	// X509 represents 3rd party generated x509 certificate to connect to Athenz.
+	X509 X509Config `yaml:"x509"`
+
 	// Version represents configuration file version.
 	Version string `yaml:"version"`
 
@@ -62,6 +65,13 @@ type Config struct {
 
 	// Mapping represents the mapping rule for mapping K8s authentication and authorization requests to Athenz requests.
 	Mapping Mapping `yaml:"map_rule"`
+}
+
+// TODO: Comment me
+type X509Config struct {
+	Cert         string `yaml:"cert"`
+	Key          string `yaml:"key"`
+	CA           string `yaml:"ca"`
 }
 
 // Logger represents logging configuration for Garm.

--- a/service/athenz.go
+++ b/service/athenz.go
@@ -63,10 +63,45 @@ func NewAthenz(cfg config.Athenz, log Logger) (Athenz, error) {
 	cfg.AuthZ.AthenzX509 = func() (*tls.Config, error) {
 		pool, err := NewX509CertPool(config.GetActualValue(cfg.AthenzRootCA))
 		if err != nil {
-			err = errors.Wrap(err, "authorization x509 certpool error")
+			err = errors.Wrap(err, "authorization x509 certpool error") // found here
 		}
 		return &tls.Config{RootCAs: pool}, err
 	}
+
+	return &athenz{
+		authConfig: cfg,
+		authn:      webhook.NewAuthenticator(cfg.AuthN),
+		authz:      webhook.NewAuthorizer(cfg.AuthZ),
+	}, nil
+}
+
+func NewX509Athenz(cfg config.Athenz, w func() (*tls.Config, error), log Logger) (Athenz, error) {
+	athenzTimeout, err := time.ParseDuration(cfg.Timeout)
+	if err != nil {
+		return nil, errors.Wrap(err, "athenz timeout parse failed")
+	}
+
+	c := webhook.Config{
+		ZMSEndpoint: cfg.URL,
+		ZTSEndpoint: cfg.URL,
+		AuthHeader:  cfg.AuthHeader,
+		Timeout:     athenzTimeout,
+		LogProvider: log.GetProvider(),
+		LogFlags:    log.GetLogFlags(),
+	}
+	cfg.AuthN.Config = c
+	cfg.AuthZ.Config = c
+
+	cfg.AuthZ.AthenzClientAuthnx509Mode = true
+	cfg.AuthZ.AthenzX509 = w
+
+	// cfg.AuthZ.AthenzX509 = func() (*tls.Config, error) {
+	// 	pool, err := NewX509CertPool(config.GetActualValue(cfg.AthenzRootCA))
+	// 	if err != nil {
+	// 		err = errors.Wrap(err, "authorization x509 certpool error") // found here
+	// 	}
+	// 	return &tls.Config{RootCAs: pool}, err
+	// }
 
 	return &athenz{
 		authConfig: cfg,

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -175,10 +175,10 @@ type CertReloaderCfg struct {
 	// if init mode: if it fails to read from cert/key files, it will return error.
 	// if non-init mode: it will keep using the cache if it fails to read from cert/key files.
 	// Init     bool
-	CertPath     string        // the cert file path i.e) /var/run/athenz/tls.cert
-	KeyPath      string        // the key file path i.e) /var/run/athenz/tls.key
-	AthenzRootCa string        // the root CA file path i.e) /var/run/athenz/root_ca.pem
-	Logger       logger        // custom log function for errors, optional
+	CertPath     string // the cert file path i.e) /var/run/athenz/tls.cert
+	KeyPath      string // the key file path i.e) /var/run/athenz/tls.key
+	AthenzRootCa string // the root CA file path i.e) /var/run/athenz/root_ca.pem
+	// Logger       logger        // custom log function for errors, optional
 	PollInterval time.Duration // TODO: Comment me
 }
 
@@ -188,6 +188,9 @@ func NewCertReloader(config CertReloaderCfg) (*CertReloader, error) {
 	// if &config.Logger == nil {
 	// 	return nil, errors.New("logger is required for CertReloader")
 	// }
+
+	// log configs:
+	glg.Info("CertPath: %s KeyPath: %s, RootCA [%s]", config.CertPath, config.KeyPath, config.AthenzRootCa)
 
 	if config.CertPath == "" || config.KeyPath == "" {
 		return nil, fmt.Errorf("both cert [%s] and key file [%s] paths are required for CertReloader", config.CertPath, config.KeyPath)

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -81,7 +81,7 @@ func (w *CertReloader) GetActualValue(val string) string {
 func (w *CertReloader) GetWebhook() func() (*tls.Config, error) {
 	return func() (*tls.Config, error) {
 		cert, err := w.GetCertFromCache()
-		pool, err := NewX509CertPool(w.GetActualValue(w.athenzRootCA))
+		// pool, err := NewX509CertPool(w.GetActualValue(w.athenzRootCA))
 
 		if err != nil {
 			return nil, err
@@ -89,9 +89,10 @@ func (w *CertReloader) GetWebhook() func() (*tls.Config, error) {
 		return &tls.Config{
 			Certificates: []tls.Certificate{*cert},
 			GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				glg.Info("GetCertificate called at %v", time.Now())
 				return cert, nil
 			},
-			RootCAs: pool,
+			// RootCAs: pool,
 		}, nil
 	}
 }

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -1,0 +1,192 @@
+// Copyright 2023 LY Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var defaultPollInterval = 1 * time.Minute
+
+// LogFn allows customized logging.
+type LogFn func(format string, args ...interface{})
+
+// CertReloader reloads the (key, cert) pair from the filesystem when
+// the cert file is updated.
+type CertReloader struct {
+	l            sync.RWMutex
+	certFile     string
+	keyFile      string
+	cert         *tls.Certificate
+	certPEM      []byte
+	keyPEM       []byte
+	mtime        time.Time
+	pollInterval time.Duration
+	// logger       logger
+	stop chan struct{}
+}
+
+// GetCertFromCache returns the latest known certificate.
+func (w *CertReloader) GetCertFromCache() (*tls.Certificate, error) {
+	w.l.RLock()
+	c := w.cert
+	w.l.RUnlock()
+	return c, nil
+}
+
+// GetCertAndKeyFromCache returns the latest known key and certificate in raw bytes.
+func (w *CertReloader) GetCertAndKeyFromCache() ([]byte, []byte, error) {
+	w.l.RLock()
+	k := w.keyPEM
+	c := w.certPEM
+	w.l.RUnlock()
+	return k, c, nil
+}
+
+// type IdentityAthenzX509 = func() (*tls.Config, error)
+func (w *CertReloader) GetWebhook() func() (*tls.Config, error) {
+	return func() (*tls.Config, error) {
+		cert, err := w.GetCertFromCache()
+		if err != nil {
+			return nil, err
+		}
+		return &tls.Config{
+			Certificates: []tls.Certificate{*cert},
+		}, nil
+	}
+}
+
+// Close stops CertReloader (or stops refreshing).
+func (w *CertReloader) Close() error {
+	w.stop <- struct{}{}
+	return nil
+}
+
+// loadLocalCertAndKey loads cert & its key from local filesystem and update its own cache if the file has changed.
+// Used to be called as "maybeReload"
+func (w *CertReloader) loadLocalCertAndKey() error {
+	st, err := os.Stat(w.certFile)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to stat %s", w.certFile))
+	}
+	if !st.ModTime().After(w.mtime) {
+		return nil
+	}
+	cert, err := tls.LoadX509KeyPair(w.certFile, w.keyFile)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to load cert from %s,%s", w.certFile, w.keyFile))
+	}
+	certPEM, err := os.ReadFile(w.certFile)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to load cert from %s", w.certFile))
+	}
+	keyPEM, err := os.ReadFile(w.keyFile)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to load key from %s", w.keyFile))
+	}
+	w.l.Lock()
+	w.cert = &cert
+	w.certPEM = certPEM
+	w.keyPEM = keyPEM
+	w.mtime = st.ModTime()
+	w.l.Unlock()
+	// w.logger("certs reloaded from local file: key[%s], cert[%s] at %v", w.keyFile, w.certFile, time.Now()) // TODO: Rename log
+	return nil
+}
+
+func (w *CertReloader) pollRefresh() error {
+	poll := time.NewTicker(w.pollInterval)
+	defer poll.Stop()
+	for {
+		select {
+		case <-poll.C:
+			if err := w.loadLocalCertAndKey(); err != nil {
+				// w.logger("cert reload error from local file: key[%s], cert[%s]: %v\n", w.keyFile, w.certFile, err) // TODO: Rename log
+			}
+		case <-w.stop:
+			return nil
+		}
+	}
+}
+
+// UpdateCertificate update certificate and key in cert reloader.
+func (w *CertReloader) UpdateCertificate(certPEM []byte, keyPEM []byte) error {
+	w.l.Lock()
+	defer w.l.Unlock()
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return errors.Wrap(err, "unable to create tls.Certificate from provided PEM data")
+	}
+
+	w.cert = &cert
+	w.certPEM = certPEM
+	w.keyPEM = keyPEM
+	w.mtime = time.Now()
+
+	// w.logger("certs updated at %v", w.mtime) // TODO: Rename log
+
+	return nil
+}
+
+// CertReloaderCfg contains the config for cert reload.
+type CertReloaderCfg struct {
+	// if init mode: if it fails to read from cert/key files, it will return error.
+	// if non-init mode: it will keep using the cache if it fails to read from cert/key files.
+	// Init     bool
+	CertPath string // the cert file path i.e) /var/run/athenz/tls.cert
+	KeyPath  string // the key file path i.e) /var/run/athenz/tls.key
+	// Logger       logger        // custom log function for errors, optional
+	PollInterval time.Duration // TODO: Comment me
+}
+
+// NewCertReloader returns a CertReloader that reloads the (key, cert) pair whenever
+// the cert file changes on the filesystem.
+func NewCertReloader(config CertReloaderCfg) (*CertReloader, error) {
+	// if &config.Logger == nil {
+	// 	return nil, errors.New("logger is required for CertReloader")
+	// }
+
+	if config.CertPath == "" || config.KeyPath == "" {
+		return nil, errors.New("both cert and key file paths are required for CertReloader")
+	}
+
+	if config.PollInterval == 0 {
+		config.PollInterval = time.Duration(defaultPollInterval)
+	}
+
+	r := &CertReloader{
+		certFile: config.CertPath,
+		keyFile:  config.KeyPath,
+		// logger:       config.Logger,
+		pollInterval: config.PollInterval,
+		stop:         make(chan struct{}, 10),
+	}
+
+	// load file once during the initialization:
+	if err := r.loadLocalCertAndKey(); err != nil {
+		// In init mode, return initialized CertReloader and error to confirm non-existence of files.
+		return r, err
+	}
+
+	go r.pollRefresh() // make sure to read the files periodically
+	return r, nil
+}

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kpango/glg"
 	"github.com/pkg/errors"
 )
 
@@ -108,7 +109,8 @@ func (w *CertReloader) loadLocalCertAndKey() error {
 	w.keyPEM = keyPEM
 	w.mtime = st.ModTime()
 	w.l.Unlock()
-	// w.logger("certs reloaded from local file: key[%s], cert[%s] at %v", w.keyFile, w.certFile, time.Now()) // TODO: Rename log
+
+	glg.Info("certs reloaded from local file: key[%s], cert[%s] at %v", w.keyFile, w.certFile, time.Now()) // TODO: Check if it is "info"
 	return nil
 }
 
@@ -119,7 +121,7 @@ func (w *CertReloader) pollRefresh() error {
 		select {
 		case <-poll.C:
 			if err := w.loadLocalCertAndKey(); err != nil {
-				// w.logger("cert reload error from local file: key[%s], cert[%s]: %v\n", w.keyFile, w.certFile, err) // TODO: Rename log
+				glg.Info("cert reload error from local file: key[%s], cert[%s]: %v", w.keyFile, w.certFile, err) // TODO: Check if it is "info"
 			}
 		case <-w.stop:
 			return nil
@@ -142,7 +144,7 @@ func (w *CertReloader) UpdateCertificate(certPEM []byte, keyPEM []byte) error {
 	w.keyPEM = keyPEM
 	w.mtime = time.Now()
 
-	// w.logger("certs updated at %v", w.mtime) // TODO: Rename log
+	glg.Info("certs reloaded from provided PEM data at %v", time.Now()) // TODO: Check if it is "info"
 
 	return nil
 }
@@ -152,9 +154,9 @@ type CertReloaderCfg struct {
 	// if init mode: if it fails to read from cert/key files, it will return error.
 	// if non-init mode: it will keep using the cache if it fails to read from cert/key files.
 	// Init     bool
-	CertPath string // the cert file path i.e) /var/run/athenz/tls.cert
-	KeyPath  string // the key file path i.e) /var/run/athenz/tls.key
-	// Logger       logger        // custom log function for errors, optional
+	CertPath     string        // the cert file path i.e) /var/run/athenz/tls.cert
+	KeyPath      string        // the key file path i.e) /var/run/athenz/tls.key
+	Logger       logger        // custom log function for errors, optional
 	PollInterval time.Duration // TODO: Comment me
 }
 

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -71,6 +71,9 @@ func (w *CertReloader) GetWebhook() func() (*tls.Config, error) {
 		}
 		return &tls.Config{
 			Certificates: []tls.Certificate{*cert},
+			GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				return cert, nil
+			},
 		}, nil
 	}
 }

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -166,7 +166,7 @@ func NewCertReloader(config CertReloaderCfg) (*CertReloader, error) {
 	// }
 
 	if config.CertPath == "" || config.KeyPath == "" {
-		return nil, errors.New("both cert and key file paths are required for CertReloader")
+		return nil, errors.New("both cert and key file paths are required for CertReloader. Got cert: " + config.CertPath + ", key: " + config.KeyPath + " instead")
 	}
 
 	if config.PollInterval == 0 {

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -168,7 +168,7 @@ func NewCertReloader(config CertReloaderCfg) (*CertReloader, error) {
 	// }
 
 	if config.CertPath == "" || config.KeyPath == "" {
-		return nil, errors.New("both cert and key file paths are required for CertReloader. Got cert: " + config.CertPath + ", key: " + config.KeyPath + " instead")
+		return nil, fmt.Errorf("both cert [%s] and key file [%s] paths are required for CertReloader", config.CertPath, config.KeyPath)
 	}
 
 	if config.PollInterval == 0 {

--- a/service/tls.go
+++ b/service/tls.go
@@ -112,5 +112,5 @@ func NewX509CertPool(path string) (*x509.CertPool, error) {
 		}
 		return pool, nil
 	}
-	return pool, errors.Wrap(err, "failed to read pem file")
+	return pool, errors.Wrap(err, "failed to read pem file") // error origin
 }

--- a/third_party/webhook/authz.go
+++ b/third_party/webhook/authz.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/kpango/glg"
 	authz "k8s.io/api/authorization/v1"
 	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
@@ -69,11 +70,13 @@ func (a *authorizer) client(ctx context.Context) (*client, error) {
 
 // clientX509 returns the client set up with x509 cert and key to make calls to Athenz.
 func (a *authorizer) clientX509(ctx context.Context) (*client, error) {
-
+	glg.Info("hello world, clientX509")
 	config, err := a.AthenzX509()
 	if err != nil {
+		glg.Info("Something went wrong here ...")
 		return nil, err
 	}
+	glg.Info("Did oyu reach here?")
 	xpX509 := &http.Transport{
 		TLSClientConfig: config,
 	}

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -67,10 +67,10 @@ func New(cfg config.Config) (GarmDaemon, error) {
 
 	// set token source (function pointer)
 	// cfg.Athenz.AuthZ.Token = token.GetToken
-	cfg.Athenz.AuthZ.AthenzClientAuthnx509Mode = true
-	cfg.Athenz.AuthZ.AthenzX509 = certReloader.GetWebhook()
+	// cfg.Athenz.AuthZ.AthenzClientAuthnx509Mode = true
+	// cfg.Athenz.AuthZ.AthenzX509 = certReloader.GetWebhook()
 
-	athenz, err := service.NewAthenz(cfg.Athenz, logger)
+	athenz, err := service.NewX509Athenz(cfg.Athenz, certReloader.GetWebhook(), logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "athenz service instantiate failed")
 	}

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -53,7 +53,7 @@ func New(cfg config.Config) (GarmDaemon, error) {
 	certReloader, err := service.NewCertReloader(service.CertReloaderCfg{
 		CertPath:     cfg.X509.Cert,
 		KeyPath:      cfg.X509.Key,
-		PollInterval: time.Minute, // TODO: Is this correct that we fix the poll interval?
+		PollInterval: time.Second, // TODO: Is this correct that we fix the poll interval?
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "cert reloader instantiate failed")

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -54,6 +54,7 @@ func New(cfg config.Config) (GarmDaemon, error) {
 		CertPath:     cfg.X509.Cert,
 		KeyPath:      cfg.X509.Key,
 		PollInterval: time.Second, // TODO: Is this correct that we fix the poll interval?
+		AthenzRootCa: cfg.Athenz.AthenzRootCA,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "cert reloader instantiate failed")

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -51,9 +51,8 @@ func New(cfg config.Config) (GarmDaemon, error) {
 
 	// TODO: use certReloader to reload cert
 	certReloader, err := service.NewCertReloader(service.CertReloaderCfg{
-		CertPath: cfg.X509.Cert,
-		KeyPath:  cfg.X509.Key,
-		// Logger: logger,
+		CertPath:     cfg.X509.Cert,
+		KeyPath:      cfg.X509.Key,
 		PollInterval: time.Minute, // TODO: Is this correct that we fix the poll interval?
 	})
 	if err != nil {

--- a/usecase/garmd_test.go
+++ b/usecase/garmd_test.go
@@ -132,8 +132,8 @@ func TestNew(t *testing.T) {
 
 					server := service.NewServer(cfg.Server, router.New(cfg.Server, handler.New(athenz)))
 					return &garm{
-						cfg:    cfg,
-						token:  token,
+						cfg: cfg,
+						// token:  token,
 						athenz: athenz,
 						server: server,
 					}
@@ -284,8 +284,8 @@ func Test_garm_Start(t *testing.T) {
 			}
 
 			g := &garm{
-				cfg:    tt.fields.cfg,
-				token:  tt.fields.token,
+				cfg: tt.fields.cfg,
+				// token:  tt.fields.token,
 				athenz: tt.fields.athenz,
 				server: tt.fields.server,
 			}


### PR DESCRIPTION
# Description
Athenz `ntoken` is deprecated.
Garm now supports 3rd party generated x509 certificate and its key to communicate with Athenz server.

New config introduced:
```go
X509 {
	Cert         string `yaml:"cert"`
	Key          string `yaml:"key"`
}
```

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
