### PR TITLE
fix: ok

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN GO111MODULE=on go mod download
 
 FROM base AS builder
 
-ENV APP_NAME garm
+ENV APP_NAME=garm
 ARG APP_VERSION='development version'
 
 COPY . .
@@ -41,9 +41,9 @@ RUN apk del build-dependencies --purge \
 # Start From Scratch For Running Environment
 FROM scratch
 # FROM alpine:latest
-LABEL maintainer "cncf-athenz-maintainers@lists.cncf.io"
+LABEL maintainer="cncf-athenz-maintainers@lists.cncf.io"
 
-ENV APP_NAME garm
+ENV APP_NAME=garm
 
 # Copy certificates for SSL/TLS
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
# Description
Garm's Dockerfile uses the legacy key value format, and we get this warning:
```
18:02:42  3 warnings found (use docker --debug to expand):
18:02:42  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 16)
18:02:42  - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 44)
18:02:42  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 46)
```

This PR will delete the warning

## Assignees
- [ ] `Assignees` is set

## Type of changes
- [ ] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
