### PR TITLE
feat: x509 certificate using garm config `v2.1.0`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,9 +57,6 @@ type Config struct {
 	// Athenz represents Athenz configuration for Garm to connect to Athenz server.
 	Athenz Athenz `yaml:"athenz"`
 
-	// X509 represents 3rd party generated x509 certificate for connecting to Athenz.
-	X509 X509Config `yaml:"x509"`
-
 	// Token represents configuration to generate n-token for connecting to Athenz.
 	Token Token `yaml:"token"`
 
@@ -127,8 +124,17 @@ type Athenz struct {
 	// Timeout represents the request timeout duration to Athenz server.
 	Timeout string `yaml:"timeout"`
 
+	// path to the X.509 certificate file i.e) /var/run/athenz/tls.crt
+	Cert string `yaml:"cert"`
+
+	// path to the X.509 certificate key i.e) /var/run/athenz/tls.key
+	Key string `yaml:"key"`
+
 	// AthenzRootCA is the Athenz root CA certificate file path for connecting to Athenz.
 	AthenzRootCA string `yaml:"root_ca"`
+
+	// duration between consecutive reads of the CA, certificate and key file i.e) 10s, 30m, 24h
+	PollInterval string `yaml:"poll_interval"`
 
 	// AuthN represents the authentication configuration.
 	AuthN webhook.AuthenticationConfig
@@ -138,13 +144,6 @@ type Athenz struct {
 
 	// Config is the common configuration for authentication and authorization server.
 	Config webhook.Config
-}
-
-// X509Config represents X.509 certificate and its key path for connecting to Athenz.
-type X509Config struct {
-	Cert         string `yaml:"cert"`          // path to the X.509 certificate file i.e) /var/run/athenz/tls.crt
-	Key          string `yaml:"key"`           // path to the X.509 certificate key i.e) /var/run/athenz/tls.key
-	PollInterval string `yaml:"poll_interval"` // duration between consecutive reads of the certificate and key file i.e) 10s, 30m, 24h
 }
 
 // Token represents the token generation details or the n-token file for Copper Argos.

--- a/config/config.go
+++ b/config/config.go
@@ -142,8 +142,9 @@ type Athenz struct {
 
 // X509Config represents X.509 certificate and its key path for connecting to Athenz.
 type X509Config struct {
-	Cert string `yaml:"cert"`
-	Key  string `yaml:"key"`
+	Cert         string `yaml:"cert"`
+	Key          string `yaml:"key"`
+	PollInterval string `yaml:"poll_interval"` // interval between reading certificate i.e) 10s, 30m ...
 }
 
 // Token represents the token generation details or the n-token file for Copper Argos.

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,9 @@ type Config struct {
 	// Athenz represents Athenz configuration for Garm to connect to Athenz server.
 	Athenz Athenz `yaml:"athenz"`
 
+	// X509 represents 3rd party generated x509 certificate for connecting to Athenz.
+	X509 X509Config `yaml:"x509"`
+
 	// Token represents configuration to generate n-token for connecting to Athenz.
 	Token Token `yaml:"token"`
 
@@ -135,6 +138,12 @@ type Athenz struct {
 
 	// Config is the common configuration for authentication and authorization server.
 	Config webhook.Config
+}
+
+// X509Config represents X.509 certificate and its key path for connecting to Athenz.
+type X509Config struct {
+	Cert string `yaml:"cert"`
+	Key  string `yaml:"key"`
 }
 
 // Token represents the token generation details or the n-token file for Copper Argos.

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// currentVersion represents the configuration version.
-	currentVersion string = "v2.0.0"
+	currentVersion string = "v2.1.0"
 	// delimiter represents delimiter used to serialize RequestInfo. Must NOT use valid characters allowed in the all the fields of RequestInfo.
 	// Choose the delimiter that RequestInfo's verb, namespace, API Group, Resource and Name CANNOT use.
 	// i.e) If end user can set its resource name with hyphens, we cannot use hyphen as delimiter.

--- a/config/config.go
+++ b/config/config.go
@@ -142,9 +142,9 @@ type Athenz struct {
 
 // X509Config represents X.509 certificate and its key path for connecting to Athenz.
 type X509Config struct {
-	Cert         string `yaml:"cert"`
-	Key          string `yaml:"key"`
-	PollInterval string `yaml:"poll_interval"` // interval between reading certificate i.e) 10s, 30m ...
+	Cert         string `yaml:"cert"`          // path to the X.509 certificate file i.e) /var/run/athenz/tls.crt
+	Key          string `yaml:"key"`           // path to the X.509 certificate key i.e) /var/run/athenz/tls.key
+	PollInterval string `yaml:"poll_interval"` // duration between consecutive reads of the certificate and key file i.e) 10s, 30m, 24h
 }
 
 // Token represents the token generation details or the n-token file for Copper Argos.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -420,7 +420,7 @@ func TestGetVersion(t *testing.T) {
 	}{
 		{
 			name: "Test get version return garm version",
-			want: "v2.0.0",
+			want: "v2.1.0",
 		},
 	}
 	for _, tt := range tests {

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -20,8 +20,9 @@ athenz:
   timeout: 5s
   root_ca: _root_ca_
 x509:
-  cert_path: "wrongful-path"
-  key_path: "wrongful-path"
+  cert: ""
+  key: ""
+  poll_interval: ""
 token:
   athenz_domain: _athenz_domain_
   service_name: _athenz_service_

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -20,8 +20,8 @@ athenz:
   timeout: 5s
   root_ca: _root_ca_
 x509:
-  cert: ""
-  key: ""
+  cert_path: "wrongful-path"
+  key_path: "wrongful-path"
 token:
   athenz_domain: _athenz_domain_
   service_name: _athenz_service_
@@ -37,14 +37,14 @@ map_rule:
     platform:
       name: aks
       # service_athenz_domains:
-      # - _tld_.k8s._segment_._uk-cluster_._namespace_._env_._k8s-cluster_._k8s-namespace_
+        # - _tld_.k8s._segment_._uk-cluster_._namespace_._env_._k8s-cluster_._k8s-namespace_
       service_athenz_domains:
-      - _kaas_namespace_.k8s._k8s_cluster_1._namespace_ # max-length = 44
-      - _kaas_namespace_.k8s._k8s_cluster_2._namespace_ # max-length = 44
+        - _kaas_namespace_.k8s._k8s_cluster_1._namespace_ # max-length = 44
+        - _kaas_namespace_.k8s._k8s_cluster_2._namespace_ # max-length = 44
       # service_athenz_domains:
-      # - _namespace_.aks
+        # - _namespace_.aks
       # service_athenz_domains:
-      # - _namespace_.k8s
+        # - _namespace_.k8s
       resource_mappings:
         k8sResource1: athenzResource1
         # k8sResource2: athenzResource2
@@ -63,8 +63,8 @@ map_rule:
       non_resource_api_group: nonres
       non_resource_namespace: nonres
       service_account_prefixes:
-      - "system:serviceaccount:"
-      - "system-serviceaccount-"
+        - "system:serviceaccount:" 
+        - "system-serviceaccount-"
       athenz_user_prefix: user.
       athenz_service_account_prefix: _kaas_namespace_.k8s._k8s_cluster_2._namespace_.service_account.
       admin_athenz_domain: aks.admin

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -18,10 +18,9 @@ athenz:
   auth_header: Athenz-Principal-Auth
   url: https://www.athenz.com/zts/v1
   timeout: 5s
-  root_ca: _root_ca_
-x509:
   cert: ""
   key: ""
+  root_ca: _root_ca_
   poll_interval: ""
 token:
   athenz_domain: _athenz_domain_

--- a/config/testdata/example_config.yaml
+++ b/config/testdata/example_config.yaml
@@ -1,4 +1,4 @@
-version: v2.0.0
+version: v2.1.0
 logger:
   log_path: /var/log/athenz/webhook.log
   log_trace: server,athenz,mapping
@@ -19,6 +19,9 @@ athenz:
   url: https://www.athenz.com/zts/v1
   timeout: 5s
   root_ca: _root_ca_
+x509:
+  cert: ""
+  key: ""
 token:
   athenz_domain: _athenz_domain_
   service_name: _athenz_service_
@@ -34,14 +37,14 @@ map_rule:
     platform:
       name: aks
       # service_athenz_domains:
-        # - _tld_.k8s._segment_._uk-cluster_._namespace_._env_._k8s-cluster_._k8s-namespace_
+      # - _tld_.k8s._segment_._uk-cluster_._namespace_._env_._k8s-cluster_._k8s-namespace_
       service_athenz_domains:
-        - _kaas_namespace_.k8s._k8s_cluster_1._namespace_ # max-length = 44
-        - _kaas_namespace_.k8s._k8s_cluster_2._namespace_ # max-length = 44
+      - _kaas_namespace_.k8s._k8s_cluster_1._namespace_ # max-length = 44
+      - _kaas_namespace_.k8s._k8s_cluster_2._namespace_ # max-length = 44
       # service_athenz_domains:
-        # - _namespace_.aks
+      # - _namespace_.aks
       # service_athenz_domains:
-        # - _namespace_.k8s
+      # - _namespace_.k8s
       resource_mappings:
         k8sResource1: athenzResource1
         # k8sResource2: athenzResource2
@@ -60,8 +63,8 @@ map_rule:
       non_resource_api_group: nonres
       non_resource_namespace: nonres
       service_account_prefixes:
-        - "system:serviceaccount:" 
-        - "system-serviceaccount-"
+      - "system:serviceaccount:"
+      - "system-serviceaccount-"
       athenz_user_prefix: user.
       athenz_service_account_prefix: _kaas_namespace_.k8s._k8s_cluster_2._namespace_.service_account.
       admin_athenz_domain: aks.admin

--- a/config/testdata/invalid_config.yaml
+++ b/config/testdata/invalid_config.yaml
@@ -19,7 +19,6 @@ auth_header: Athenz-Principal-Auth
   url: https://www.athenz.io/zts/v1
   timeout: 5s
 root_ca: root_ca
-x509:
   path_cert: ""
   path_key: ""
 token:

--- a/config/testdata/invalid_config.yaml
+++ b/config/testdata/invalid_config.yaml
@@ -1,4 +1,4 @@
-version: v2.0.0
+version: v2.1.0
 logger:
   log_path: /var/log/athenz/webhook.log
   log_trace: server,athenz,mapping
@@ -19,6 +19,9 @@ auth_header: Athenz-Principal-Auth
   url: https://www.athenz.io/zts/v1
   timeout: 5s
 root_ca: root_ca
+x509:
+  path_cert: ""
+  path_key: ""
 token:
   athenz_domain: _athenz_domain_
 service_name: _athenz_service_

--- a/k8s/garm-config.yaml
+++ b/k8s/garm-config.yaml
@@ -22,7 +22,7 @@ data:
       url: https://www.athenz.io:4443/zts/v1
       timeout: 30s
       cert: ""
-      key: "":
+      key: ""
       root_ca: _root_ca_
       poll_interval: ""
     token:

--- a/k8s/garm-config.yaml
+++ b/k8s/garm-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   config.yaml: |
     ---
-    version: v1.0.0
+    version: v2.1.0
     logger:
       log_path: /var/log/athenz/webhook.log
       log_trace: athenz,server
@@ -21,7 +21,10 @@ data:
       auth_header: Athenz-Principal-Auth
       url: https://www.athenz.io:4443/zts/v1
       timeout: 30s
+      cert: ""
+      key: "":
       root_ca: _root_ca_
+      poll_interval: ""
     token:
       athenz_domain: _athenz_domain_
       service_name: _service_name_
@@ -37,7 +40,7 @@ data:
         platform:
           name: k8s
           # service_athenz_domains:
-          #  - {{TLD}}.k8s.{{ENV}} # {{ENV}} = [prod, tool, dev]
+          # - {{TLD}}.k8s.{{ENV}} # {{ENV}} = [prod, tool, dev]
           service_athenz_domains:
             - k8s.k8s.dev
           resource_mappings:

--- a/main.go
+++ b/main.go
@@ -66,15 +66,16 @@ func run(cfg config.Config) []error {
 	}
 
 	// Check if X.509 cert mode:
-	useX509Mode := cfg.X509.Cert != "" && cfg.X509.Key != ""
-	glg.Infof("Garm is starting with X.509 mode[%t] ...", useX509Mode)
-
 	var daemon usecase.GarmDaemon
 	var daemonErr error
 
-	if useX509Mode {
+	if cfg.X509.Cert != "" && cfg.X509.Key != "" { // useX509Mode := cfg.X509.Cert != "" && cfg.X509.Key != ""
+		// TODO: Add log here instead:
+		glg.Info("🟡 TODO: Add me a good log ...")
 		daemon, daemonErr = usecase.NewX509(cfg)
 	} else {
+		// TODO: Add log here instead:
+		glg.Info("🟡 TODO: Add me a good log ...")
 		daemon, daemonErr = usecase.New(cfg)
 	}
 

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func run(cfg config.Config) []error {
 
 	// Check if X.509 cert mode:
 	useX509Mode := cfg.X509.Cert != "" && cfg.X509.Key != ""
-	glg.Info("Garm is starting with X.509 mode[", useX509Mode, "] ...")
+	glg.Infof("Garm is starting with X.509 mode[%b] ...", useX509Mode)
 
 	var daemon usecase.GarmDaemon
 	var daemonErr error

--- a/main.go
+++ b/main.go
@@ -70,12 +70,11 @@ func run(cfg config.Config) []error {
 	var daemonErr error
 
 	if cfg.Athenz.Cert != "" && cfg.Athenz.Key != "" { // useX509Mode := cfg.Athenz.Cert != "" && cfg.Athenz.Key != ""
-		// TODO: Add log here instead:
-		glg.Info("🟡 TODO: Add me a good log ...")
+		glg.Info("Garm will connect to the Athenz server using X.509 Certificate ...")
 		daemon, daemonErr = usecase.NewX509(cfg)
 	} else {
-		// TODO: Add log here instead:
-		glg.Info("🟡 TODO: Add me a good log ...")
+		glg.Info("Garm will connect to the Athenz server using an N-Token ...")
+		glg.Warn("If you want a more secure connection, you can prepare an X.509 Certificate and configure .athenz.cert and .athenz.key. Garm will then use the X.509 Certificate instead.")
 		daemon, daemonErr = usecase.New(cfg)
 	}
 

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func run(cfg config.Config) []error {
 
 	// Check if X.509 cert mode:
 	useX509Mode := cfg.X509.Cert != "" && cfg.X509.Key != ""
-	glg.Infof("Garm is starting with X.509 mode[%b] ...", useX509Mode)
+	glg.Infof("Garm is starting with X.509 mode[%t] ...", useX509Mode)
 
 	var daemon usecase.GarmDaemon
 	var daemonErr error

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func run(cfg config.Config) []error {
 	var daemon usecase.GarmDaemon
 	var daemonErr error
 
-	if cfg.X509.Cert != "" && cfg.X509.Key != "" { // useX509Mode := cfg.X509.Cert != "" && cfg.X509.Key != ""
+	if cfg.Athenz.Cert != "" && cfg.Athenz.Key != "" { // useX509Mode := cfg.Athenz.Cert != "" && cfg.Athenz.Key != ""
 		// TODO: Add log here instead:
 		glg.Info("🟡 TODO: Add me a good log ...")
 		daemon, daemonErr = usecase.NewX509(cfg)

--- a/service/athenz.go
+++ b/service/athenz.go
@@ -96,14 +96,6 @@ func NewX509Athenz(cfg config.Athenz, w func() (*tls.Config, error), log Logger)
 	cfg.AuthZ.AthenzClientAuthnx509Mode = true
 	cfg.AuthZ.AthenzX509 = w
 
-	// cfg.AuthZ.AthenzX509 = func() (*tls.Config, error) {
-	// 	pool, err := NewX509CertPool(config.GetActualValue(cfg.AthenzRootCA))
-	// 	if err != nil {
-	// 		err = errors.Wrap(err, "authorization x509 certpool error") // found here
-	// 	}
-	// 	return &tls.Config{RootCAs: pool}, err
-	// }
-
 	return &athenz{
 		authConfig: cfg,
 		authn:      webhook.NewAuthenticator(cfg.AuthN),

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -153,14 +153,10 @@ func (w *CertReloader) pollRefresh() error {
 
 // CertReloaderCfg contains the config for cert reload.
 type CertReloaderCfg struct {
-	// if init mode: if it fails to read from cert/key files, it will return error.
-	// if non-init mode: it will keep using the cache if it fails to read from cert/key files.
-	// Init     bool
-	CertPath     string // the cert file path i.e) /var/run/athenz/tls.cert
-	KeyPath      string // the key file path i.e) /var/run/athenz/tls.key
-	AthenzRootCa string // the root CA file path i.e) /var/run/athenz/root_ca.pem
-	// Logger       logger        // custom log function for errors, optional
-	PollInterval time.Duration // TODO: Comment me
+	CertPath     string        // path to the X.509 certificate file i.e) /var/run/athenz/tls.crt
+	KeyPath      string        // path to the X.509 certificate key i.e) /var/run/athenz/tls.key
+	AthenzRootCa string        // the root CA file path i.e) /var/run/athenz/root_ca.pem
+	PollInterval time.Duration // duration between consecutive reads of the certificate and key file i.e) 10s, 30m, 24h
 }
 
 // NewCertReloader returns a CertReloader that reloads the (key, cert) pair whenever

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -151,26 +151,6 @@ func (w *CertReloader) pollRefresh() error {
 	}
 }
 
-// UpdateCertificate update certificate and key in cert reloader.
-func (w *CertReloader) UpdateCertificate(certPEM []byte, keyPEM []byte) error {
-	w.l.Lock()
-	defer w.l.Unlock()
-
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		return errors.Wrap(err, "unable to create tls.Certificate from provided PEM data")
-	}
-
-	w.cert = &cert
-	w.certPEM = certPEM
-	w.keyPEM = keyPEM
-	w.mtime = time.Now()
-
-	glg.Info("certs reloaded from provided PEM data at %v", time.Now()) // TODO: Check if it is "info"
-
-	return nil
-}
-
 // CertReloaderCfg contains the config for cert reload.
 type CertReloaderCfg struct {
 	// if init mode: if it fails to read from cert/key files, it will return error.

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -64,12 +64,6 @@ func (w *CertReloader) GetWebhook() func() (*tls.Config, error) {
 		}
 		return &tls.Config{
 			Certificates: []tls.Certificate{*cert},
-			// TODO: Let's see if this is enough
-			// GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			// 	glg.Info("GetCertificate called at %v", time.Now())
-			// 	return cert, nil
-			// },
-			// RootCAs: pool,
 		}, nil
 	}
 }

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -57,7 +57,6 @@ func (w *CertReloader) GetCertFromCache() (*tls.Certificate, error) {
 func (w *CertReloader) GetWebhook() func() (*tls.Config, error) {
 	return func() (*tls.Config, error) {
 		cert, err := w.GetCertFromCache()
-		// pool, err := NewX509CertPool(w.GetActualValue(w.athenzRootCA))
 
 		if err != nil {
 			return nil, err

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -42,9 +42,11 @@ type CertReloader struct {
 	l            sync.RWMutex
 	certPath     string
 	keyPath      string
+	caPath       string
 	cert         *tls.Certificate
 	certPEM      []byte
 	keyPEM       []byte
+	caPEM        []byte // TODO: Actually store it and return in GetWebhook
 	mtime        time.Time
 	pollInterval time.Duration
 	stop         chan struct{}
@@ -129,9 +131,9 @@ func (w *CertReloader) pollRefresh() error {
 
 // CertReloaderCfg contains the config for cert reload.
 type CertReloaderCfg struct {
-	CertPath string // path to the X.509 certificate file i.e) /var/run/athenz/tls.crt
-	KeyPath  string // path to the X.509 certificate key i.e) /var/run/athenz/tls.key
-	// TODO: RootCA Path string
+	CertPath     string        // path to the X.509 certificate file i.e) /var/run/athenz/tls.crt
+	KeyPath      string        // path to the X.509 certificate key i.e) /var/run/athenz/tls.key
+	CaPath       string        // path to the X.509 CA file i.e) /var/run/athenz/ca.crt
 	PollInterval time.Duration // duration between consecutive reads of the certificate and key file i.e) 10s, 30m, 24h
 }
 
@@ -149,9 +151,9 @@ func NewCertReloader(config CertReloaderCfg) (*CertReloader, error) {
 	}
 
 	r := &CertReloader{
-		certPath: config.CertPath,
-		keyPath:  config.KeyPath,
-		// logger:       config.Logger,
+		certPath:     config.CertPath,
+		keyPath:      config.KeyPath,
+		caPath:       config.CaPath,
 		pollInterval: config.PollInterval,
 		stop:         make(chan struct{}, 10),
 	}

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -61,9 +61,9 @@ func (w *CertReloader) GetCertFromCache() (*tls.Certificate, error) {
 	return c, nil
 }
 
-// GetWebhook returns a function that is used to get X.509 Certificate stored in memory to connect to Athenz server
+// GetTLSConfigFunc returns a tls-config-returning-function that is used to get X.509 Certificate stored in memory to connect to Athenz server
 // type IdentityAthenzX509 = func() (*tls.Config, error)
-func (w *CertReloader) GetWebhook() func() (*tls.Config, error) {
+func (w *CertReloader) GetTLSConfigFunc() func() (*tls.Config, error) {
 	return func() (*tls.Config, error) {
 		cert, err := w.GetCertFromCache()
 

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -135,10 +135,6 @@ func (w *CertReloader) loadLocalCertAndKey() error {
 		return errors.Wrap(err, fmt.Sprintf("unable to load key from %s", w.keyPath))
 	}
 
-	if err != nil {
-		return err
-	}
-
 	w.l.Lock()
 	w.cert = &cert
 	w.certPEM = certPEM

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -101,7 +101,7 @@ func (w *CertReloader) loadCAPool() error {
 	}
 
 	if !caPool.AppendCertsFromPEM(caPEM) {
-		return errors.New("Certification Failed")
+		return errors.New("appending ca certificate into ca pool has failed")
 	}
 
 	// Finally:

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -66,10 +66,11 @@ func (w *CertReloader) GetWebhook() func() (*tls.Config, error) {
 		}
 		return &tls.Config{
 			Certificates: []tls.Certificate{*cert},
-			GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-				glg.Info("GetCertificate called at %v", time.Now())
-				return cert, nil
-			},
+			// TODO: Let's see if this is enough
+			// GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			// 	glg.Info("GetCertificate called at %v", time.Now())
+			// 	return cert, nil
+			// },
 			// RootCAs: pool,
 		}, nil
 	}

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -101,7 +101,7 @@ func (w *CertReloader) loadCAPool() error {
 	}
 
 	if !caPool.AppendCertsFromPEM(caPEM) {
-		return errors.New("appending ca certificate into ca pool has failed")
+		return errors.New("Certification Failed") // TODO: Something like "appending ca certificate into ca pool has failed"
 	}
 
 	// Finally:

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -41,7 +41,7 @@ type CertReloader struct {
 	keyPEM       []byte
 	mtime        time.Time
 	pollInterval time.Duration
-	stop chan struct{}
+	stop         chan struct{}
 }
 
 // GetCertFromCache returns the latest known certificate.

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -1,0 +1,221 @@
+// Copyright 2023 LY Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kpango/glg"
+	"github.com/pkg/errors"
+)
+
+var defaultPollInterval = 1 * time.Minute
+
+// LogFn allows customized logging.
+type LogFn func(format string, args ...interface{})
+
+// CertReloader reloads the (key, cert) pair from the filesystem when
+// the cert file is updated.
+type CertReloader struct {
+	l            sync.RWMutex
+	certFile     string
+	keyFile      string
+	athenzRootCA string
+	cert         *tls.Certificate
+	certPEM      []byte
+	keyPEM       []byte
+	mtime        time.Time
+	pollInterval time.Duration
+	// logger       logger
+	stop chan struct{}
+}
+
+// GetCertFromCache returns the latest known certificate.
+func (w *CertReloader) GetCertFromCache() (*tls.Certificate, error) {
+	w.l.RLock()
+	c := w.cert
+	w.l.RUnlock()
+	return c, nil
+}
+
+// GetCertAndKeyFromCache returns the latest known key and certificate in raw bytes.
+func (w *CertReloader) GetCertAndKeyFromCache() ([]byte, []byte, error) {
+	w.l.RLock()
+	k := w.keyPEM
+	c := w.certPEM
+	w.l.RUnlock()
+	return k, c, nil
+}
+
+// checkPrefixAndSuffix checks if the given string has given prefix and suffix.
+func (w *CertReloader) checkPrefixAndSuffix(str, pref, suf string) bool {
+	return strings.HasPrefix(str, pref) && strings.HasSuffix(str, suf)
+}
+
+// GetActualValue returns the environment variable value if the given val has "_" prefix and suffix, otherwise returns val directly.
+func (w *CertReloader) GetActualValue(val string) string {
+	if w.checkPrefixAndSuffix(val, "_", "_") {
+		return os.Getenv(strings.TrimPrefix(strings.TrimSuffix(val, "_"), "_"))
+	}
+	return val
+}
+
+// type IdentityAthenzX509 = func() (*tls.Config, error)
+func (w *CertReloader) GetWebhook() func() (*tls.Config, error) {
+	return func() (*tls.Config, error) {
+		cert, err := w.GetCertFromCache()
+		// pool, err := NewX509CertPool(w.GetActualValue(w.athenzRootCA))
+
+		if err != nil {
+			return nil, err
+		}
+		return &tls.Config{
+			Certificates: []tls.Certificate{*cert},
+			GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				glg.Info("GetCertificate called at %v", time.Now())
+				return cert, nil
+			},
+			// RootCAs: pool,
+		}, nil
+	}
+}
+
+// Close stops CertReloader (or stops refreshing).
+func (w *CertReloader) Close() error {
+	w.stop <- struct{}{}
+	return nil
+}
+
+// loadLocalCertAndKey loads cert & its key from local filesystem and update its own cache if the file has changed.
+// Used to be called as "maybeReload"
+func (w *CertReloader) loadLocalCertAndKey() error {
+	st, err := os.Stat(w.certFile)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to stat %s", w.certFile))
+	}
+	if !st.ModTime().After(w.mtime) {
+		return nil
+	}
+	cert, err := tls.LoadX509KeyPair(w.certFile, w.keyFile)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to load cert from %s,%s", w.certFile, w.keyFile))
+	}
+	certPEM, err := os.ReadFile(w.certFile)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to load cert from %s", w.certFile))
+	}
+	keyPEM, err := os.ReadFile(w.keyFile)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to load key from %s", w.keyFile))
+	}
+	w.l.Lock()
+	w.cert = &cert
+	w.certPEM = certPEM
+	w.keyPEM = keyPEM
+	w.mtime = st.ModTime()
+	w.l.Unlock()
+
+	glg.Info("certs reloaded from local file: key[%s], cert[%s] at %v", w.keyFile, w.certFile, time.Now()) // TODO: Check if it is "info"
+	return nil
+}
+
+func (w *CertReloader) pollRefresh() error {
+	poll := time.NewTicker(w.pollInterval)
+	defer poll.Stop()
+	for {
+		select {
+		case <-poll.C:
+			if err := w.loadLocalCertAndKey(); err != nil {
+				glg.Info("cert reload error from local file: key[%s], cert[%s]: %v", w.keyFile, w.certFile, err) // TODO: Check if it is "info"
+			}
+		case <-w.stop:
+			return nil
+		}
+	}
+}
+
+// UpdateCertificate update certificate and key in cert reloader.
+func (w *CertReloader) UpdateCertificate(certPEM []byte, keyPEM []byte) error {
+	w.l.Lock()
+	defer w.l.Unlock()
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return errors.Wrap(err, "unable to create tls.Certificate from provided PEM data")
+	}
+
+	w.cert = &cert
+	w.certPEM = certPEM
+	w.keyPEM = keyPEM
+	w.mtime = time.Now()
+
+	glg.Info("certs reloaded from provided PEM data at %v", time.Now()) // TODO: Check if it is "info"
+
+	return nil
+}
+
+// CertReloaderCfg contains the config for cert reload.
+type CertReloaderCfg struct {
+	// if init mode: if it fails to read from cert/key files, it will return error.
+	// if non-init mode: it will keep using the cache if it fails to read from cert/key files.
+	// Init     bool
+	CertPath     string // the cert file path i.e) /var/run/athenz/tls.cert
+	KeyPath      string // the key file path i.e) /var/run/athenz/tls.key
+	AthenzRootCa string // the root CA file path i.e) /var/run/athenz/root_ca.pem
+	// Logger       logger        // custom log function for errors, optional
+	PollInterval time.Duration // TODO: Comment me
+}
+
+// NewCertReloader returns a CertReloader that reloads the (key, cert) pair whenever
+// the cert file changes on the filesystem.
+func NewCertReloader(config CertReloaderCfg) (*CertReloader, error) {
+	// if &config.Logger == nil {
+	// 	return nil, errors.New("logger is required for CertReloader")
+	// }
+
+	// log configs:
+	glg.Info("CertPath: %s KeyPath: %s, RootCA [%s]", config.CertPath, config.KeyPath, config.AthenzRootCa)
+
+	if config.CertPath == "" || config.KeyPath == "" {
+		return nil, fmt.Errorf("both cert [%s] and key file [%s] paths are required for CertReloader", config.CertPath, config.KeyPath)
+	}
+
+	if config.PollInterval == 0 {
+		config.PollInterval = time.Duration(defaultPollInterval)
+	}
+
+	r := &CertReloader{
+		certFile: config.CertPath,
+		keyFile:  config.KeyPath,
+		// logger:       config.Logger,
+		pollInterval: config.PollInterval,
+		stop:         make(chan struct{}, 10),
+		athenzRootCA: config.AthenzRootCa,
+	}
+
+	// load file once during the initialization:
+	if err := r.loadLocalCertAndKey(); err != nil {
+		// In init mode, return initialized CertReloader and error to confirm non-existence of files.
+		return r, err
+	}
+
+	go r.pollRefresh() // make sure to read the files periodically
+	return r, nil
+}

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -146,6 +146,7 @@ func (w *CertReloader) loadLocalCertAndKey() error {
 }
 
 func (w *CertReloader) pollRefresh() error {
+	glg.Debugf("Starting to poll .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] every[%s] ...", w.certPath, w.keyPath, w.caPath, w.pollInterval)
 	poll := time.NewTicker(w.pollInterval)
 	defer poll.Stop()
 	for {

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -131,10 +131,12 @@ func (w *CertReloader) pollRefresh() error {
 
 // CertReloaderCfg contains the config for cert reload.
 type CertReloaderCfg struct {
-	CertPath     string        // path to the X.509 certificate file i.e) /var/run/athenz/tls.crt
-	KeyPath      string        // path to the X.509 certificate key i.e) /var/run/athenz/tls.key
-	CaPath       string        // path to the X.509 CA file i.e) /var/run/athenz/ca.crt
-	PollInterval time.Duration // duration between consecutive reads of the certificate and key file i.e) 10s, 30m, 24h
+	CertPath string // path to the X.509 certificate file i.e) /var/run/athenz/tls.crt
+	KeyPath  string // path to the X.509 certificate key i.e) /var/run/athenz/tls.key
+	CaPath   string // path to the X.509 CA file i.e) /var/run/athenz/ca.crt (This is optional)
+	// duration between consecutive reads of the certificate and key file i.e) 10s, 30m, 24h
+	// This is not optional as Garm is not aware how long the cert is valid for.
+	PollInterval time.Duration
 }
 
 // NewCertReloader returns a CertReloader that reloads the (key, cert) pair whenever

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -107,16 +107,16 @@ func (w *CertReloader) loadLocalCAPool() (*x509.CertPool, error) {
 }
 
 // loadLocalCertAndKey loads cert & its key from local filesystem and update its own cache if the file has changed.
-// Used to be called as "maybeReload"
+
 func (w *CertReloader) loadLocalCertAndKey() error {
-	glg.Debugf("Attempting to load .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] from local file ...", w.certPath, w.keyPath, w.caPath)
+	// glg.Debugf("Attempting to load .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] from local file ...", w.certPath, w.keyPath, w.caPath)
 	st, err := os.Stat(w.certPath)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("unable to stat %s", w.certPath))
 	}
-	// This logic will only reload the cert if the file has changed; greatly improve the performance.
+
 	if !st.ModTime().After(w.mtime) {
-		glg.Debugf("Skipping to load .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] from local file as it has not changed ...", w.certPath, w.keyPath, w.caPath)
+		// glg.Debugf("Skipping to load .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] from local file as it has not changed ...", w.certPath, w.keyPath, w.caPath)
 		return nil
 	}
 	cert, err := tls.LoadX509KeyPair(w.certPath, w.keyPath)
@@ -149,7 +149,7 @@ func (w *CertReloader) loadLocalCertAndKey() error {
 }
 
 func (w *CertReloader) pollRefresh() error {
-	glg.Debugf("Starting periodic poll refresh for .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] every[%s] ...", w.certPath, w.keyPath, w.caPath, w.pollInterval)
+	// glg.Debugf("Starting periodic poll refresh for .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] every[%s] ...", w.certPath, w.keyPath, w.caPath, w.pollInterval)
 	poll := time.NewTicker(w.pollInterval)
 	defer poll.Stop()
 	for {

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -129,15 +129,16 @@ func (w *CertReloader) pollRefresh() error {
 
 // CertReloaderCfg contains the config for cert reload.
 type CertReloaderCfg struct {
-	CertPath     string        // path to the X.509 certificate file i.e) /var/run/athenz/tls.crt
-	KeyPath      string        // path to the X.509 certificate key i.e) /var/run/athenz/tls.key
+	CertPath string // path to the X.509 certificate file i.e) /var/run/athenz/tls.crt
+	KeyPath  string // path to the X.509 certificate key i.e) /var/run/athenz/tls.key
+	// TODO: RootCA Path string
 	PollInterval time.Duration // duration between consecutive reads of the certificate and key file i.e) 10s, 30m, 24h
 }
 
 // NewCertReloader returns a CertReloader that reloads the (key, cert) pair whenever
 // the cert file changes on the filesystem.
 func NewCertReloader(config CertReloaderCfg) (*CertReloader, error) {
-	glg.Infof("Booting X.509 certificate reloader with arg .x509.cert[%s] .x509.key[%s] .x509.poll_interval[%s]", config.CertPath, config.KeyPath, config.PollInterval)
+	glg.Infof("Booting X.509 certificate reloader with arg .athenz.cert[%s] .athenz.key[%s] .athenz.poll_interval[%s]", config.CertPath, config.KeyPath, config.PollInterval)
 
 	if config.CertPath == "" || config.KeyPath == "" {
 		return nil, fmt.Errorf("both cert [%s] and key file [%s] paths are required for CertReloader", config.CertPath, config.KeyPath)

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -191,6 +191,7 @@ func NewCertReloader(config CertReloaderCfg) (*CertReloader, error) {
 	// }
 
 	// log configs:
+	// TODO: Possibly a better logger:
 	glg.Info("CertPath: %s KeyPath: %s, RootCA [%s]", config.CertPath, config.KeyPath, config.AthenzRootCa)
 
 	if config.CertPath == "" || config.KeyPath == "" {

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -141,7 +141,7 @@ func (w *CertReloader) loadLocalCertAndKey() error {
 	w.mtime = st.ModTime()
 	w.l.Unlock()
 
-	glg.Infof("Successfully loaded X.509 certificate [%s] and its key [%s] from local file", w.certPath, w.keyPath)
+	glg.Infof("Successfully loaded .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] from local file", w.certPath, w.keyPath, w.caPath)
 	return nil
 }
 
@@ -152,7 +152,7 @@ func (w *CertReloader) pollRefresh() error {
 		select {
 		case <-poll.C:
 			if err := w.loadLocalCertAndKey(); err != nil {
-				glg.Warnf("Failed to load X.509 certificate [%s] and its key [%s] from local file", w.certPath, w.keyPath)
+				glg.Warnf("Failed to load .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] from local file: %v", w.certPath, w.keyPath, w.caPath, err)
 			}
 		case <-w.stop:
 			return nil
@@ -176,7 +176,7 @@ type CertReloaderCfg struct {
 // NewCertReloader returns a CertReloader that reloads the (key, cert) pair whenever
 // the cert file changes on the filesystem.
 func NewCertReloader(config CertReloaderCfg) (*CertReloader, error) {
-	glg.Infof("Booting X.509 certificate reloader with arg .athenz.cert[%s] .athenz.key[%s] .athenz.poll_interval[%s]", config.CertPath, config.KeyPath, config.PollInterval)
+	glg.Infof("Booting X.509 certificate reloader with arg .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] .athenz.poll_interval[%s]", config.CertPath, config.KeyPath, config.CaPath, config.PollInterval)
 
 	if config.CertPath == "" || config.KeyPath == "" {
 		return nil, fmt.Errorf("both cert [%s] and key file [%s] paths are required for CertReloader", config.CertPath, config.KeyPath)

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -132,7 +132,7 @@ func (w *CertReloader) loadLocalCertAndKey() error {
 	w.mtime = st.ModTime()
 	w.l.Unlock()
 
-	glg.Info("certs reloaded from local file: key[%s], cert[%s] at %v", w.keyFile, w.certFile, time.Now()) // TODO: Check if it is "info"
+	glg.Infof("Successfully loaded X.509 certificate [%s] and its key [%s] from local file", w.certFile, w.keyFile)
 	return nil
 }
 
@@ -143,7 +143,7 @@ func (w *CertReloader) pollRefresh() error {
 		select {
 		case <-poll.C:
 			if err := w.loadLocalCertAndKey(); err != nil {
-				glg.Info("cert reload error from local file: key[%s], cert[%s]: %v", w.keyFile, w.certFile, err) // TODO: Check if it is "info"
+				glg.Warnf("Failed to load X.509 certificate [%s] and its key [%s] from local file", w.certFile, w.keyFile)
 			}
 		case <-w.stop:
 			return nil

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -109,12 +109,14 @@ func (w *CertReloader) loadLocalCAPool() (*x509.CertPool, error) {
 // loadLocalCertAndKey loads cert & its key from local filesystem and update its own cache if the file has changed.
 // Used to be called as "maybeReload"
 func (w *CertReloader) loadLocalCertAndKey() error {
-	glg.Debugf("Loading .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] from local file ...", w.certPath, w.keyPath, w.caPath)
+	glg.Debugf("Attempting to load .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] from local file ...", w.certPath, w.keyPath, w.caPath)
 	st, err := os.Stat(w.certPath)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("unable to stat %s", w.certPath))
 	}
+	// This logic will only reload the cert if the file has changed; greatly improve the performance.
 	if !st.ModTime().After(w.mtime) {
+		glg.Debugf("Skipping to load .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] from local file as it has not changed ...", w.certPath, w.keyPath, w.caPath)
 		return nil
 	}
 	cert, err := tls.LoadX509KeyPair(w.certPath, w.keyPath)

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -36,13 +36,11 @@ type CertReloader struct {
 	l            sync.RWMutex
 	certFile     string
 	keyFile      string
-	athenzRootCA string
 	cert         *tls.Certificate
 	certPEM      []byte
 	keyPEM       []byte
 	mtime        time.Time
 	pollInterval time.Duration
-	// logger       logger
 	stop chan struct{}
 }
 

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -109,6 +109,7 @@ func (w *CertReloader) loadLocalCAPool() (*x509.CertPool, error) {
 // loadLocalCertAndKey loads cert & its key from local filesystem and update its own cache if the file has changed.
 // Used to be called as "maybeReload"
 func (w *CertReloader) loadLocalCertAndKey() error {
+	glg.Debugf("Loading .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] from local file ...", w.certPath, w.keyPath, w.caPath)
 	st, err := os.Stat(w.certPath)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("unable to stat %s", w.certPath))
@@ -146,7 +147,7 @@ func (w *CertReloader) loadLocalCertAndKey() error {
 }
 
 func (w *CertReloader) pollRefresh() error {
-	glg.Debugf("Starting to poll .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] every[%s] ...", w.certPath, w.keyPath, w.caPath, w.pollInterval)
+	glg.Debugf("Starting periodic poll refresh for .athenz.cert[%s] .athenz.key[%s] .athenz.root_ca[%s] every[%s] ...", w.certPath, w.keyPath, w.caPath, w.pollInterval)
 	poll := time.NewTicker(w.pollInterval)
 	defer poll.Stop()
 	for {

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: This code is based on athenz/k8s-athenz-sia's implementation:
+// TODO: https://github.com/AthenZ/k8s-athenz-sia/blob/main/pkg/util/cert-reloader.go
+// TODO: Yet, the original code is tailored specifically to k8s-athenz-sia's logic.
+// TODO: It would be beneficial to develop a more general-purpose library for this functionality in the future.
+// TODO: This way, both Garm and k8s-athenz-sia could utilize the same library.
 package service
 
 import (

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -14,7 +14,8 @@
 
 // TODO: This code is based on athenz/k8s-athenz-sia's implementation:
 // TODO: https://github.com/AthenZ/k8s-athenz-sia/blob/main/pkg/util/cert-reloader.go
-// TODO: Yet, the original code is tailored specifically to k8s-athenz-sia's logic.
+// TODO: Yet, the original code is tailored specifically to k8s-athenz-sia's logic
+// TODO: So we could not copy the k8s-athenz-sia's cert-reloader code as is.
 // TODO: It would be beneficial to develop a more general-purpose library for this functionality in the future.
 // TODO: This way, both Garm and k8s-athenz-sia could utilize the same library.
 package service

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -140,7 +140,7 @@ type CertReloaderCfg struct {
 // NewCertReloader returns a CertReloader that reloads the (key, cert) pair whenever
 // the cert file changes on the filesystem.
 func NewCertReloader(config CertReloaderCfg) (*CertReloader, error) {
-	glg.Infof("Booting X.509 Certificate reloader with x509.cert[%s], x509.key[%s], x509.poll_interval[%s]", config.CertPath, config.KeyPath, config.PollInterval)
+	glg.Infof("Booting X.509 certificate reloader with arg .x509.cert[%s] .x509.key[%s] .x509.poll_interval[%s]", config.CertPath, config.KeyPath, config.PollInterval)
 
 	if config.CertPath == "" || config.KeyPath == "" {
 		return nil, fmt.Errorf("both cert [%s] and key file [%s] paths are required for CertReloader", config.CertPath, config.KeyPath)

--- a/service/token.go
+++ b/service/token.go
@@ -85,6 +85,8 @@ func NewTokenService(cfg config.Token) (TokenService, error) {
 // StartTokenUpdater returns a TokenService.
 // It starts a go routine to update the token periodically.
 func (t *token) StartTokenUpdater(ctx context.Context) TokenService {
+	glg.Info("Starting ntoken updater with refresh duration[", t.refreshDuration, "] ...")
+
 	go func() {
 		err := t.update()
 		if err != nil {

--- a/service/token.go
+++ b/service/token.go
@@ -85,7 +85,7 @@ func NewTokenService(cfg config.Token) (TokenService, error) {
 // StartTokenUpdater returns a TokenService.
 // It starts a go routine to update the token periodically.
 func (t *token) StartTokenUpdater(ctx context.Context) TokenService {
-	glg.Info("Starting ntoken updater with refresh duration[", t.refreshDuration, "] ...")
+	glg.Infof("Starting ntoken updater with refresh duration [%s] ...", t.refreshDuration)
 
 	go func() {
 		err := t.update()

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -70,7 +70,7 @@ func New(cfg config.Config) (GarmDaemon, error) {
 func NewX509(cfg config.Config) (GarmDaemon, error) {
 	pollInterval, err := time.ParseDuration(cfg.X509.PollInterval)
 	if err != nil {
-		return nil, errors.Wrap(err, "config invalid .x509.poll_interval ["+cfg.X509.PollInterval+"]")
+		return nil, errors.Wrap(err, "invalid 	config .x509.poll_interval ["+cfg.X509.PollInterval+"]")
 	}
 
 	certReloader, err := service.NewCertReloader(service.CertReloaderCfg{

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -70,7 +70,7 @@ func New(cfg config.Config) (GarmDaemon, error) {
 func NewX509(cfg config.Config) (GarmDaemon, error) {
 	pollInterval, err := time.ParseDuration(cfg.X509.PollInterval)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid .x509.poll_interval ["+cfg.X509.PollInterval+"]")
+		return nil, errors.Wrap(err, "config invalid .x509.poll_interval ["+cfg.X509.PollInterval+"]")
 	}
 
 	certReloader, err := service.NewCertReloader(service.CertReloaderCfg{

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -77,7 +77,6 @@ func NewX509(cfg config.Config) (GarmDaemon, error) {
 		CertPath:     cfg.X509.Cert,
 		KeyPath:      cfg.X509.Key,
 		PollInterval: pollInterval,
-		AthenzRootCa: cfg.Athenz.AthenzRootCA,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "cert reloader instantiate failed")

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -104,8 +104,6 @@ func NewX509(cfg config.Config) (GarmDaemon, error) {
 
 // Start returns an error slice channel. This error channel reports the errors inside Garm server.
 func (g *garm) Start(ctx context.Context) chan []error {
-	// TODO: Does this have to be here? or it can be simply started during the initialization?:
-	// TODO: Prolly yes.
 	if g.token != nil {
 		g.token.StartTokenUpdater(ctx)
 	}

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -74,9 +74,9 @@ func NewX509(cfg config.Config) (GarmDaemon, error) {
 	}
 
 	certReloader, err := service.NewCertReloader(service.CertReloaderCfg{
-		CertPath: cfg.Athenz.Cert,
-		KeyPath:  cfg.Athenz.Key,
-		// TODO: Root CA
+		CertPath:     cfg.Athenz.Cert,
+		KeyPath:      cfg.Athenz.Key,
+		CaPath:       cfg.Athenz.AthenzRootCA,
 		PollInterval: pollInterval,
 	})
 	if err != nil {

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -68,14 +68,15 @@ func New(cfg config.Config) (GarmDaemon, error) {
 }
 
 func NewX509(cfg config.Config) (GarmDaemon, error) {
-	pollInterval, err := time.ParseDuration(cfg.X509.PollInterval)
+	pollInterval, err := time.ParseDuration(cfg.Athenz.PollInterval)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid 	config .x509.poll_interval ["+cfg.X509.PollInterval+"]")
+		return nil, errors.Wrap(err, "invalid 	config .athenz.poll_interval ["+cfg.Athenz.PollInterval+"]")
 	}
 
 	certReloader, err := service.NewCertReloader(service.CertReloaderCfg{
-		CertPath:     cfg.X509.Cert,
-		KeyPath:      cfg.X509.Key,
+		CertPath: cfg.Athenz.Cert,
+		KeyPath:  cfg.Athenz.Key,
+		// TODO: Root CA
 		PollInterval: pollInterval,
 	})
 	if err != nil {

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -70,7 +70,7 @@ func New(cfg config.Config) (GarmDaemon, error) {
 func NewX509(cfg config.Config) (GarmDaemon, error) {
 	pollInterval, err := time.ParseDuration(cfg.Athenz.PollInterval)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid 	config .athenz.poll_interval ["+cfg.Athenz.PollInterval+"]")
+		return nil, errors.Wrap(err, "invalid config .athenz.poll_interval ["+cfg.Athenz.PollInterval+"]")
 	}
 
 	certReloader, err := service.NewCertReloader(service.CertReloaderCfg{

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -47,7 +47,7 @@ func New(cfg config.Config) (GarmDaemon, error) {
 	logger := service.NewLogger(cfg.Logger)
 	useX509Mode := cfg.X509.Cert != "" && cfg.X509.Key != ""
 	// Log out here:
-	glg.Info("Garm is starting with X.509 mode=", useX509Mode)
+	glg.Info("Garm is starting with X.509 mode[", useX509Mode, "] ...")
 
 	resolver := service.NewResolver(cfg.Mapping)
 	// set up mappers:

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/AthenZ/garm/v3/handler"
 	"github.com/AthenZ/garm/v3/router"
 	"github.com/AthenZ/garm/v3/service"
+	"github.com/kpango/glg"
 	"github.com/pkg/errors"
 )
 
@@ -43,13 +44,15 @@ type garm struct {
 // The daemon contains a token service authentication and authorization server.
 // This function will also initialize the mapping rules for the authentication and authorization check.
 func New(cfg config.Config) (GarmDaemon, error) {
+	logger := service.NewLogger(cfg.Logger)
 	useX509Mode := cfg.X509.Cert != "" && cfg.X509.Key != ""
+	// Log out here:
+	glg.Info("Garm is starting with X.509 mode=", useX509Mode)
 
 	var token service.TokenService
 	var certReloader *service.CertReloader
 	var athenz service.Athenz
 	var err error
-	logger := service.NewLogger(cfg.Logger)
 
 	if useX509Mode {
 		certReloader, err = service.NewCertReloader(service.CertReloaderCfg{

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -68,10 +68,15 @@ func New(cfg config.Config) (GarmDaemon, error) {
 }
 
 func NewX509(cfg config.Config) (GarmDaemon, error) {
+	pollInterval, err := time.ParseDuration(cfg.X509.PollInterval)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid .x509.poll_interval ["+cfg.X509.PollInterval+"]")
+	}
+
 	certReloader, err := service.NewCertReloader(service.CertReloaderCfg{
 		CertPath:     cfg.X509.Cert,
 		KeyPath:      cfg.X509.Key,
-		PollInterval: time.Second, // TODO: Is this correct that we fix the poll interval?
+		PollInterval: pollInterval,
 		AthenzRootCa: cfg.Athenz.AthenzRootCA,
 	})
 	if err != nil {

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -89,7 +89,7 @@ func NewX509(cfg config.Config) (GarmDaemon, error) {
 	cfg.Athenz.AuthN.Mapper = service.NewUserMapper(resolver)
 
 	// Create Athenz object for X.509:
-	athenz, err := service.NewX509Athenz(cfg.Athenz, certReloader.GetWebhook(), service.NewLogger(cfg.Logger))
+	athenz, err := service.NewX509Athenz(cfg.Athenz, certReloader.GetTLSConfigFunc(), service.NewLogger(cfg.Logger))
 	if err != nil {
 		return nil, errors.Wrap(err, "athenz service instantiate failed")
 	}

--- a/usecase/garmd.go
+++ b/usecase/garmd.go
@@ -76,7 +76,7 @@ func NewX509(cfg config.Config) (GarmDaemon, error) {
 	certReloader, err := service.NewCertReloader(service.CertReloaderCfg{
 		CertPath:     cfg.Athenz.Cert,
 		KeyPath:      cfg.Athenz.Key,
-		CaPath:       cfg.Athenz.AthenzRootCA,
+		CaPath:       config.GetActualValue(cfg.Athenz.AthenzRootCA),
 		PollInterval: pollInterval,
 	})
 	if err != nil {


### PR DESCRIPTION
# Description

X.509 Mode Log:
```
2024-12-03 07:31:54    [INFO]:    Garm is starting with X.509 mode[true] ...                                                         
2024-12-03 07:31:54    [INFO]:    Booting X.509 Certificate reloader with .x509.cert[/var/run/athenz/service.cert.pem] .x509.key[/var/
run/athenz/test-tls.key] .x509.poll_interval[15m0s]                                                                                  
2024-12-03 07:31:54    [INFO]:    Successfully loaded X.509 certificate [/var/run/athenz/service.cert.pem] and its key [/var/run/athe
nz/test-tls.key] from local file                                                                                                     
2024-12-03 07:31:54    [WARN]:    time: invalid duration ""                                                                          
2024-12-03 07:31:54    [DEBG]:    Running garm as user [garm] with UID [100] ...                                                     
2024-12-03 07:31:54    [INFO]:    garm api server starting                                                                           
2024-12-03 07:31:54    [INFO]:    garm health check server starting 
```

Ntoken mode:
```
2024-12-03 07:38:24    [INFO]:    Garm is starting with X.509 mode[false] ...
2024-12-03 07:38:24    [WARN]:    time: invalid duration ""
2024-12-03 07:38:24    [INFO]:    Starting ntoken updater with refresh duration [30s] ...
2024-12-03 07:38:24    [DEBG]:    Running garm as user [garm] with UID [100] ...
2024-12-03 07:38:24    [INFO]:    garm health check server starting
2024-12-03 07:38:24    [INFO]:    garm api server starting
```

## TODOs
- [x] Implementation
- [x] Refactor
- [x] Handle code TODOs
- [x] Clean Logger (mimic SIA)

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
