### PR TITLE
Feat: remove non-used `certPEM` `keyPEM`

### DIFF
--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -126,7 +126,9 @@ func (w *CertReloader) loadLocalCertAndKey() error {
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("unable to load cert from %s,%s", w.certPath, w.keyPath))
 	}
-	// TODO: I have this feeling that the following code does not care of reading files properly:
+
+	// TODO: The following code potentially has the bug as the following issue describes:
+	// TODO: https://github.com/AthenZ/k8s-athenz-sia/issues/177
 	// certPEM, err := os.ReadFile(w.certPath)
 	// if err != nil {
 	// 	return errors.Wrap(err, fmt.Sprintf("unable to load cert from %s", w.certPath))

--- a/service/cert-reloader.go
+++ b/service/cert-reloader.go
@@ -40,13 +40,13 @@ type LogFn func(format string, args ...interface{})
 // CertReloader reloads the (key, cert) pair from the filesystem when
 // the cert file is updated.
 type CertReloader struct {
-	l            sync.RWMutex
-	certPath     string
-	keyPath      string
-	caPath       string
-	cert         *tls.Certificate
-	certPEM      []byte
-	keyPEM       []byte
+	l        sync.RWMutex
+	certPath string
+	keyPath  string
+	caPath   string
+	cert     *tls.Certificate
+	// certPEM      []byte
+	// keyPEM       []byte
 	caPool       *x509.CertPool // This is optional and can be nil
 	mtime        time.Time
 	pollInterval time.Duration
@@ -126,19 +126,20 @@ func (w *CertReloader) loadLocalCertAndKey() error {
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("unable to load cert from %s,%s", w.certPath, w.keyPath))
 	}
-	certPEM, err := os.ReadFile(w.certPath)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("unable to load cert from %s", w.certPath))
-	}
-	keyPEM, err := os.ReadFile(w.keyPath)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("unable to load key from %s", w.keyPath))
-	}
+	// TODO: I have this feeling that the following code does not care of reading files properly:
+	// certPEM, err := os.ReadFile(w.certPath)
+	// if err != nil {
+	// 	return errors.Wrap(err, fmt.Sprintf("unable to load cert from %s", w.certPath))
+	// }
+	// keyPEM, err := os.ReadFile(w.keyPath)
+	// if err != nil {
+	// 	return errors.Wrap(err, fmt.Sprintf("unable to load key from %s", w.keyPath))
+	// }
 
 	w.l.Lock()
 	w.cert = &cert
-	w.certPEM = certPEM
-	w.keyPEM = keyPEM
+	// w.certPEM = certPEM
+	// w.keyPEM = keyPEM
 	w.mtime = st.ModTime()
 	w.l.Unlock()
 


### PR DESCRIPTION
# Background
The current code unnecessarily reads the cert and key files when `LoadX509KeyPair()` is sufficient for using an X.509 Certificate to authenticate against the Athenz server.

## What's done?
Comment out not-used code to improve speed

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
